### PR TITLE
乱数表のマスタデータ作成

### DIFF
--- a/config/random_number_table/doubles/coat1_player4.yml
+++ b/config/random_number_table/doubles/coat1_player4.yml
@@ -1,0 +1,13 @@
+# コート1面、プレイヤー4人
+sequence1:
+  coat1:
+    home: [1, 2]
+    away: [3, 4]
+sequence2:
+  coat1:
+    home: [1, 3]
+    away: [2, 4]
+sequence3:
+  coat1:
+    home: [1, 4]
+    away: [2, 3]

--- a/config/random_number_table/doubles/coat1_player5.yml
+++ b/config/random_number_table/doubles/coat1_player5.yml
@@ -1,0 +1,61 @@
+# コート1面、プレイヤー5人
+sequence1:
+  coat1:
+    home: [1, 2]
+    away: [3, 4]
+sequence2:
+  coat1:
+    home: [1, 5]
+    away: [2, 3]
+sequence3:
+  coat1:
+    home: [1, 4]
+    away: [2, 5]
+sequence4:
+  coat1:
+    home: [1, 3]
+    away: [4, 5]
+sequence5:
+  coat1:
+    home: [2, 4]
+    away: [3, 5]
+sequence6:
+  coat1:
+    home: [1, 3]
+    away: [2, 4]
+sequence7:
+  coat1:
+    home: [3, 5]
+    away: [1, 2]
+sequence8:
+  coat1:
+    home: [4, 5]
+    away: [1, 2]
+sequence9:
+  coat1:
+    home: [3, 4]
+    away: [1, 5]
+sequence10:
+  coat1:
+    home: [2, 3]
+    away: [4, 5]
+sequence11:
+  coat1:
+    home: [1, 4]
+    away: [2, 3]
+sequence12:
+  coat1:
+    home: [2, 5]
+    away: [1, 2]
+sequence13:
+  coat1:
+    home: [2, 4]
+    away: [1, 5]
+sequence14:
+  coat1:
+    home: [3, 5]
+    away: [1, 4]
+sequence15:
+  coat1:
+    home: [2, 5]
+    away: [3, 4]

--- a/config/random_number_table/doubles/coat1_player6.yml
+++ b/config/random_number_table/doubles/coat1_player6.yml
@@ -1,0 +1,121 @@
+# コート1面、プレイヤー6人
+sequence1:
+  coat1:
+    home: [1, 2]
+    away: [3, 4]
+sequence2:
+  coat1:
+    home: [1, 5]
+    away: [2, 6]
+sequence3:
+  coat1:
+    home: [3, 6]
+    away: [4, 5]
+sequence4:
+  coat1:
+    home: [1, 3]
+    away: [2, 5]
+sequence5:
+  coat1:
+    home: [2, 4]
+    away: [5, 6]
+sequence6:
+  coat1:
+    home: [1, 6]
+    away: [3, 5]
+sequence7:
+  coat1:
+    home: [2, 3]
+    away: [4, 6]
+sequence8:
+  coat1:
+    home: [1, 4]
+    away: [5, 6]
+sequence9:
+  coat1:
+    home: [2, 5]
+    away: [3, 6]
+sequence10:
+  coat1:
+    home: [1, 5]
+    away: [3, 4]
+sequence11:
+  coat1:
+    home: [2, 6]
+    away: [4, 5]
+sequence12:
+  coat1:
+    home: [1, 6]
+    away: [2, 3]
+sequence13:
+  coat1:
+    home: [3, 5]
+    away: [4, 6]
+sequence14:
+  coat1:
+    home: [1, 4]
+    away: [2, 5]
+sequence15:
+  coat1:
+    home: [3, 6]
+    away: [1, 2]
+sequence16:
+  coat1:
+    home: [4, 5]
+    away: [1, 3]
+sequence17:
+  coat1:
+    home: [2, 4]
+    away: [3, 6]
+sequence18:
+  coat1:
+    home: [5, 6]
+    away: [1, 2]
+sequence19:
+  coat1:
+    home: [3, 4]
+    away: [2, 5]
+sequence20:
+  coat1:
+    home: [1, 6]
+    away: [4, 5]
+sequence21:
+  coat1:
+    home: [2, 3]
+    away: [5, 6]
+sequence22:
+  coat1:
+    home: [1, 5]
+    away: [3, 4]
+sequence23:
+  coat1:
+    home: [2, 6]
+    away: [1, 4]
+sequence24:
+  coat1:
+    home: [3, 5]
+    away: [2, 6]
+sequence25:
+  coat1:
+    home: [4, 6]
+    away: [1, 5]
+sequence26:
+  coat1:
+    home: [2, 4]
+    away: [3, 5]
+sequence27:
+  coat1:
+    home: [1, 3]
+    away: [5, 6]
+sequence28:
+  coat1:
+    home: [4, 5]
+    away: [2, 3]
+sequence29:
+  coat1:
+    home: [1, 6]
+    away: [3, 4]
+sequence30:
+  coat1:
+    home: [2, 5]
+    away: [1, 6]

--- a/config/random_number_table/doubles/coat1_player7.yml
+++ b/config/random_number_table/doubles/coat1_player7.yml
@@ -1,0 +1,141 @@
+# コート1面、プレイヤー7人
+sequence1:
+  coat1:
+    home: [1, 2]
+    away: [3, 4]
+sequence2:
+  coat1:
+    home: [1, 5]
+    away: [6, 7]
+sequence3:
+  coat1:
+    home: [2, 3]
+    away: [5, 6]
+sequence4:
+  coat1:
+    home: [4, 7]
+    away: [2, 5]
+sequence5:
+  coat1:
+    home: [1, 3]
+    away: [6, 7]
+sequence6:
+  coat1:
+    home: [2, 4]
+    away: [5, 6]
+sequence7:
+  coat1:
+    home: [1, 7]
+    away: [3, 5]
+sequence8:
+  coat1:
+    home: [2, 6]
+    away: [4, 7]
+sequence9:
+  coat1:
+    home: [1, 5]
+    away: [3, 6]
+sequence10:
+  coat1:
+    home: [2, 7]
+    away: [4, 5]
+sequence11:
+  coat1:
+    home: [1, 6]
+    away: [3, 7]
+sequence12:
+  coat1:
+    home: [2, 5]
+    away: [4, 6]
+sequence13:
+  coat1:
+    home: [1, 4]
+    away: [3, 5]
+sequence14:
+  coat1:
+    home: [2, 6]
+    away: [7, 5]
+sequence15:
+  coat1:
+    home: [1, 3]
+    away: [4, 6]
+sequence16:
+  coat1:
+    home: [2, 7]
+    away: [5, 6]
+sequence17:
+  coat1:
+    home: [1, 4]
+    away: [3, 7]
+sequence18:
+  coat1:
+    home: [2, 5]
+    away: [6, 7]
+sequence19:
+  coat1:
+    home: [1, 6]
+    away: [3, 4]
+sequence20:
+  coat1:
+    home: [2, 5]
+    away: [7, 6]
+sequence21:
+  coat1:
+    home: [1, 7]
+    away: [3, 5]
+sequence22:
+  coat1:
+    home: [2, 4]
+    away: [6, 7]
+sequence23:
+  coat1:
+    home: [1, 5]
+    away: [3, 6]
+sequence24:
+  coat1:
+    home: [2, 7]
+    away: [4, 6]
+sequence25:
+  coat1:
+    home: [1, 3]
+    away: [5, 7]
+sequence26:
+  coat1:
+    home: [2, 6]
+    away: [4, 5]
+sequence27:
+  coat1:
+    home: [1, 4]
+    away: [7, 6]
+sequence28:
+  coat1:
+    home: [2, 3]
+    away: [5, 7]
+sequence29:
+  coat1:
+    home: [1, 6]
+    away: [4, 5]
+sequence30:
+  coat1:
+    home: [2, 7]
+    away: [3, 6]
+sequence31:
+  coat1:
+    home: [1, 5]
+    away: [4, 7]
+sequence32:
+  coat1:
+    home: [2, 3]
+    away: [6, 7]
+sequence33:
+  coat1:
+    home: [1, 4]
+    away: [5, 6]
+sequence34:
+  coat1:
+    home: [2, 7]
+    away: [3, 5]
+sequence35:
+  coat1:
+    home: [1, 6]
+    away: [4, 7]

--- a/config/random_number_table/doubles/coat1_player8.yml
+++ b/config/random_number_table/doubles/coat1_player8.yml
@@ -1,0 +1,225 @@
+# コート1面、プレイヤー8人
+sequence1:
+  coat1:
+    home: [1, 2]
+    away: [3, 4]
+sequence2:
+  coat1:
+    home: [5, 6]
+    away: [7, 8]
+sequence3:
+  coat1:
+    home: [1, 5]
+    away: [2, 6]
+sequence4:
+  coat1:
+    home: [3, 7]
+    away: [4, 8]
+sequence5:
+  coat1:
+    home: [1, 3]
+    away: [5, 7]
+sequence6:
+  coat1:
+    home: [2, 4]
+    away: [6, 8]
+sequence7:
+  coat1:
+    home: [1, 7]
+    away: [2, 8]
+sequence8:
+  coat1:
+    home: [3, 5]
+    away: [4, 6]
+sequence9:
+  coat1:
+    home: [1, 6]
+    away: [2, 5]
+sequence10:
+  coat1:
+    home: [3, 8]
+    away: [4, 7]
+sequence11:
+  coat1:
+    home: [1, 4]
+    away: [5, 8]
+sequence12:
+  coat1:
+    home: [2, 3]
+    away: [6, 7]
+sequence13:
+  coat1:
+    home: [1, 8]
+    away: [2, 7]
+sequence14:
+  coat1:
+    home: [3, 6]
+    away: [4, 5]
+sequence15:
+  coat1:
+    home: [1, 2]
+    away: [5, 6]
+sequence16:
+  coat1:
+    home: [3, 4]
+    away: [7, 8]
+sequence17:
+  coat1:
+    home: [1, 5]
+    away: [3, 7]
+sequence18:
+  coat1:
+    home: [2, 6]
+    away: [4, 8]
+sequence19:
+  coat1:
+    home: [1, 3]
+    away: [2, 4]
+sequence20:
+  coat1:
+    home: [5, 7]
+    away: [6, 8]
+sequence21:
+  coat1:
+    home: [1, 7]
+    away: [4, 6]
+sequence22:
+  coat1:
+    home: [2, 8]
+    away: [3, 5]
+sequence23:
+  coat1:
+    home: [1, 6]
+    away: [3, 8]
+sequence24:
+  coat1:
+    home: [2, 5]
+    away: [4, 7]
+sequence25:
+  coat1:
+    home: [1, 4]
+    away: [6, 7]
+sequence26:
+  coat1:
+    home: [2, 3]
+    away: [5, 8]
+sequence27:
+  coat1:
+    home: [1, 8]
+    away: [4, 5]
+sequence28:
+  coat1:
+    home: [2, 7]
+    away: [3, 6]
+sequence29:
+  coat1:
+    home: [1, 2]
+    away: [7, 8]
+sequence30:
+  coat1:
+    home: [3, 4]
+    away: [5, 6]
+sequence31:
+  coat1:
+    home: [1, 5]
+    away: [4, 8]
+sequence32:
+  coat1:
+    home: [2, 6]
+    away: [3, 7]
+sequence33:
+  coat1:
+    home: [1, 3]
+    away: [6, 8]
+sequence34:
+  coat1:
+    home: [2, 4]
+    away: [5, 7]
+sequence35:
+  coat1:
+    home: [1, 7]
+    away: [3, 5]
+sequence36:
+  coat1:
+    home: [2, 8]
+    away: [4, 6]
+sequence37:
+  coat1:
+    home: [1, 6]
+    away: [4, 7]
+sequence38:
+  coat1:
+    home: [2, 5]
+    away: [3, 8]
+sequence39:
+  coat1:
+    home: [1, 4]
+    away: [2, 3]
+sequence40:
+  coat1:
+    home: [5, 8]
+    away: [6, 7]
+sequence41:
+  coat1:
+    home: [1, 8]
+    away: [3, 6]
+sequence42:
+  coat1:
+    home: [2, 7]
+    away: [4, 5]
+sequence43:
+  coat1:
+    home: [1, 2]
+    away: [5, 6]
+sequence44:
+  coat1:
+    home: [3, 4]
+    away: [7, 8]
+sequence45:
+  coat1:
+    home: [1, 5]
+    away: [2, 6]
+sequence46:
+  coat1:
+    home: [3, 7]
+    away: [4, 8]
+sequence47:
+  coat1:
+    home: [1, 3]
+    away: [5, 7]
+sequence48:
+  coat1:
+    home: [2, 4]
+    away: [6, 8]
+sequence49:
+  coat1:
+    home: [1, 7]
+    away: [2, 8]
+sequence50:
+  coat1:
+    home: [3, 5]
+    away: [4, 6]
+sequence51:
+  coat1:
+    home: [1, 6]
+    away: [2, 5]
+sequence52:
+  coat1:
+    home: [3, 8]
+    away: [4, 7]
+sequence53:
+  coat1:
+    home: [1, 4]
+    away: [5, 8]
+sequence54:
+  coat1:
+    home: [2, 3]
+    away: [6, 7]
+sequence55:
+  coat1:
+    home: [1, 8]
+    away: [2, 7]
+sequence56:
+  coat1:
+    home: [3, 6]
+    away: [4, 5]

--- a/config/random_number_table/doubles/coat2_player10.yml
+++ b/config/random_number_table/doubles/coat2_player10.yml
@@ -1,0 +1,211 @@
+# コート2面、プレイヤー10人
+sequence1:
+  coat1:
+    home: [1, 2]
+    away: [3, 4]
+  coat2:
+    home: [5, 6]
+    away: [7, 8]
+sequence2:
+  coat1:
+    home: [1, 5]
+    away: [9, 10]
+  coat2:
+    home: [2, 6]
+    away: [3, 7]
+sequence3:
+  coat1:
+    home: [1, 3]
+    away: [5, 9]
+  coat2:
+    home: [4, 8]
+    away: [6, 10]
+sequence4:
+  coat1:
+    home: [1, 7]
+    away: [2, 10]
+  coat2:
+    home: [3, 5]
+    away: [4, 6]
+sequence5:
+  coat1:
+    home: [1, 6]
+    away: [2, 3]
+  coat2:
+    home: [7, 9]
+    away: [8, 10]
+sequence6:
+  coat1:
+    home: [1, 8]
+    away: [2, 5]
+  coat2:
+    home: [3, 10]
+    away: [4, 7]
+sequence7:
+  coat1:
+    home: [1, 4]
+    away: [5, 10]
+  coat2:
+    home: [2, 9]
+    away: [6, 7]
+sequence8:
+  coat1:
+    home: [1, 10]
+    away: [3, 6]
+  coat2:
+    home: [2, 8]
+    away: [4, 5]
+sequence9:
+  coat1:
+    home: [1, 9]
+    away: [3, 8]
+  coat2:
+    home: [2, 4]
+    away: [7, 10]
+sequence10:
+  coat1:
+    home: [2, 7]
+    away: [3, 9]
+  coat2:
+    home: [4, 10]
+    away: [5, 6]
+sequence11:
+  coat1:
+    home: [1, 2]
+    away: [5, 7]
+  coat2:
+    home: [3, 4]
+    away: [9, 10]
+sequence12:
+  coat1:
+    home: [1, 5]
+    away: [3, 7]
+  coat2:
+    home: [2, 6]
+    away: [4, 8]
+sequence13:
+  coat1:
+    home: [1, 3]
+    away: [2, 4]
+  coat2:
+    home: [5, 9]
+    away: [6, 10]
+sequence14:
+  coat1:
+    home: [1, 7]
+    away: [4, 6]
+  coat2:
+    home: [2, 10]
+    away: [8, 9]
+sequence15:
+  coat1:
+    home: [1, 6]
+    away: [8, 10]
+  coat2:
+    home: [2, 3]
+    away: [5, 7]
+sequence16:
+  coat1:
+    home: [1, 8]
+    away: [4, 7]
+  coat2:
+    home: [2, 5]
+    away: [9, 10]
+sequence17:
+  coat1:
+    home: [1, 4]
+    away: [6, 7]
+  coat2:
+    home: [2, 9]
+    away: [3, 8]
+sequence18:
+  coat1:
+    home: [1, 10]
+    away: [4, 5]
+  coat2:
+    home: [2, 8]
+    away: [6, 9]
+sequence19:
+  coat1:
+    home: [1, 9]
+    away: [4, 10]
+  coat2:
+    home: [2, 7]
+    away: [3, 6]
+sequence20:
+  coat1:
+    home: [3, 5]
+    away: [6, 8]
+  coat2:
+    home: [4, 9]
+    away: [7, 10]
+sequence21:
+  coat1:
+    home: [1, 2]
+    away: [9, 10]
+  coat2:
+    home: [3, 4]
+    away: [5, 6]
+sequence22:
+  coat1:
+    home: [1, 5]
+    away: [4, 8]
+  coat2:
+    home: [2, 6]
+    away: [7, 9]
+sequence23:
+  coat1:
+    home: [1, 3]
+    away: [6, 10]
+  coat2:
+    home: [2, 4]
+    away: [5, 8]
+sequence24:
+  coat1:
+    home: [1, 7]
+    away: [3, 10]
+  coat2:
+    home: [2, 9]
+    away: [5, 6]
+sequence25:
+  coat1:
+    home: [1, 6]
+    away: [4, 9]
+  coat2:
+    home: [2, 3]
+    away: [8, 10]
+sequence26:
+  coat1:
+    home: [1, 8]
+    away: [3, 9]
+  coat2:
+    home: [2, 5]
+    away: [7, 10]
+sequence27:
+  coat1:
+    home: [1, 4]
+    away: [3, 8]
+  coat2:
+    home: [6, 7]
+    away: [9, 10]
+sequence28:
+  coat1:
+    home: [1, 10]
+    away: [2, 8]
+  coat2:
+    home: [5, 7]
+    away: [6, 9]
+sequence29:
+  coat1:
+    home: [1, 9]
+    away: [2, 7]
+  coat2:
+    home: [3, 5]
+    away: [4, 10]
+sequence30:
+  coat1:
+    home: [3, 6]
+    away: [4, 7]
+  coat2:
+    home: [5, 8]
+    away: [9, 10]

--- a/config/random_number_table/doubles/coat2_player11.yml
+++ b/config/random_number_table/doubles/coat2_player11.yml
@@ -1,0 +1,211 @@
+# コート2面、プレイヤー11人
+sequence1:
+  coat1:
+    home: [1, 2]
+    away: [3, 4]
+  coat2:
+    home: [5, 6]
+    away: [7, 8]
+sequence2:
+  coat1:
+    home: [1, 5]
+    away: [9, 10]
+  coat2:
+    home: [2, 11]
+    away: [3, 7]
+sequence3:
+  coat1:
+    home: [1, 3]
+    away: [5, 9]
+  coat2:
+    home: [4, 8]
+    away: [6, 10]
+sequence4:
+  coat1:
+    home: [1, 7]
+    away: [2, 10]
+  coat2:
+    home: [3, 5]
+    away: [4, 6]
+sequence5:
+  coat1:
+    home: [1, 6]
+    away: [2, 3]
+  coat2:
+    home: [7, 9]
+    away: [8, 11]
+sequence6:
+  coat1:
+    home: [1, 8]
+    away: [2, 5]
+  coat2:
+    home: [3, 10]
+    away: [4, 7]
+sequence7:
+  coat1:
+    home: [1, 4]
+    away: [5, 11]
+  coat2:
+    home: [2, 9]
+    away: [6, 7]
+sequence8:
+  coat1:
+    home: [1, 10]
+    away: [3, 6]
+  coat2:
+    home: [2, 8]
+    away: [4, 5]
+sequence9:
+  coat1:
+    home: [1, 9]
+    away: [3, 8]
+  coat2:
+    home: [2, 4]
+    away: [7, 11]
+sequence10:
+  coat1:
+    home: [2, 7]
+    away: [3, 9]
+  coat2:
+    home: [4, 10]
+    away: [5, 6]
+sequence11:
+  coat1:
+    home: [1, 11]
+    away: [3, 11]
+  coat2:
+    home: [5, 7]
+    away: [8, 9]
+sequence12:
+  coat1:
+    home: [1, 2]
+    away: [5, 8]
+  coat2:
+    home: [3, 4]
+    away: [6, 9]
+sequence13:
+  coat1:
+    home: [1, 5]
+    away: [3, 7]
+  coat2:
+    home: [2, 6]
+    away: [4, 11]
+sequence14:
+  coat1:
+    home: [1, 3]
+    away: [2, 4]
+  coat2:
+    home: [5, 9]
+    away: [6, 10]
+sequence15:
+  coat1:
+    home: [1, 7]
+    away: [4, 6]
+  coat2:
+    home: [2, 10]
+    away: [8, 11]
+sequence16:
+  coat1:
+    home: [1, 6]
+    away: [8, 10]
+  coat2:
+    home: [2, 3]
+    away: [5, 7]
+sequence17:
+  coat1:
+    home: [1, 8]
+    away: [4, 7]
+  coat2:
+    home: [2, 5]
+    away: [9, 11]
+sequence18:
+  coat1:
+    home: [1, 4]
+    away: [6, 7]
+  coat2:
+    home: [2, 9]
+    away: [3, 8]
+sequence19:
+  coat1:
+    home: [1, 10]
+    away: [4, 5]
+  coat2:
+    home: [2, 8]
+    away: [6, 11]
+sequence20:
+  coat1:
+    home: [1, 9]
+    away: [4, 10]
+  coat2:
+    home: [2, 7]
+    away: [3, 6]
+sequence21:
+  coat1:
+    home: [3, 5]
+    away: [6, 8]
+  coat2:
+    home: [4, 9]
+    away: [7, 11]
+sequence22:
+  coat1:
+    home: [1, 11]
+    away: [2, 6]
+  coat2:
+    home: [3, 10]
+    away: [5, 8]
+sequence23:
+  coat1:
+    home: [1, 2]
+    away: [9, 10]
+  coat2:
+    home: [3, 4]
+    away: [5, 7]
+sequence24:
+  coat1:
+    home: [1, 5]
+    away: [4, 8]
+  coat2:
+    home: [2, 11]
+    away: [6, 9]
+sequence25:
+  coat1:
+    home: [1, 3]
+    away: [6, 10]
+  coat2:
+    home: [2, 4]
+    away: [7, 8]
+sequence26:
+  coat1:
+    home: [1, 7]
+    away: [3, 11]
+  coat2:
+    home: [2, 9]
+    away: [5, 6]
+sequence27:
+  coat1:
+    home: [1, 6]
+    away: [4, 9]
+  coat2:
+    home: [2, 3]
+    away: [8, 10]
+sequence28:
+  coat1:
+    home: [1, 8]
+    away: [3, 9]
+  coat2:
+    home: [2, 5]
+    away: [7, 10]
+sequence29:
+  coat1:
+    home: [1, 4]
+    away: [3, 8]
+  coat2:
+    home: [6, 7]
+    away: [9, 11]
+sequence30:
+  coat1:
+    home: [1, 10]
+    away: [2, 8]
+  coat2:
+    home: [5, 11]
+    away: [6, 9]

--- a/config/random_number_table/doubles/coat2_player12.yml
+++ b/config/random_number_table/doubles/coat2_player12.yml
@@ -1,0 +1,211 @@
+# コート2面、プレイヤー12人
+sequence1:
+  coat1:
+    home: [1, 2]
+    away: [3, 4]
+  coat2:
+    home: [5, 6]
+    away: [7, 8]
+sequence2:
+  coat1:
+    home: [1, 5]
+    away: [9, 10]
+  coat2:
+    home: [2, 11]
+    away: [3, 7]
+sequence3:
+  coat1:
+    home: [1, 3]
+    away: [5, 9]
+  coat2:
+    home: [4, 8]
+    away: [6, 12]
+sequence4:
+  coat1:
+    home: [1, 7]
+    away: [2, 12]
+  coat2:
+    home: [3, 5]
+    away: [4, 6]
+sequence5:
+  coat1:
+    home: [1, 6]
+    away: [2, 3]
+  coat2:
+    home: [7, 9]
+    away: [8, 11]
+sequence6:
+  coat1:
+    home: [1, 8]
+    away: [2, 5]
+  coat2:
+    home: [3, 10]
+    away: [4, 7]
+sequence7:
+  coat1:
+    home: [1, 4]
+    away: [5, 11]
+  coat2:
+    home: [2, 9]
+    away: [6, 7]
+sequence8:
+  coat1:
+    home: [1, 10]
+    away: [3, 6]
+  coat2:
+    home: [2, 8]
+    away: [4, 5]
+sequence9:
+  coat1:
+    home: [1, 9]
+    away: [3, 8]
+  coat2:
+    home: [2, 4]
+    away: [7, 12]
+sequence10:
+  coat1:
+    home: [2, 7]
+    away: [3, 9]
+  coat2:
+    home: [4, 10]
+    away: [5, 6]
+sequence11:
+  coat1:
+    home: [1, 11]
+    away: [3, 12]
+  coat2:
+    home: [5, 7]
+    away: [8, 9]
+sequence12:
+  coat1:
+    home: [6, 8]
+    away: [10, 12]
+  coat2:
+    home: [4, 11]
+    away: [1, 12]
+sequence13:
+  coat1:
+    home: [1, 2]
+    away: [5, 8]
+  coat2:
+    home: [3, 4]
+    away: [6, 9]
+sequence14:
+  coat1:
+    home: [1, 5]
+    away: [3, 7]
+  coat2:
+    home: [2, 6]
+    away: [4, 12]
+sequence15:
+  coat1:
+    home: [1, 3]
+    away: [2, 4]
+  coat2:
+    home: [5, 9]
+    away: [6, 10]
+sequence16:
+  coat1:
+    home: [1, 7]
+    away: [4, 6]
+  coat2:
+    home: [2, 10]
+    away: [8, 12]
+sequence17:
+  coat1:
+    home: [1, 6]
+    away: [8, 10]
+  coat2:
+    home: [2, 3]
+    away: [5, 7]
+sequence18:
+  coat1:
+    home: [1, 8]
+    away: [4, 7]
+  coat2:
+    home: [2, 5]
+    away: [9, 11]
+sequence19:
+  coat1:
+    home: [1, 4]
+    away: [6, 7]
+  coat2:
+    home: [2, 9]
+    away: [3, 8]
+sequence20:
+  coat1:
+    home: [1, 10]
+    away: [4, 5]
+  coat2:
+    home: [2, 8]
+    away: [6, 11]
+sequence21:
+  coat1:
+    home: [1, 9]
+    away: [4, 10]
+  coat2:
+    home: [2, 7]
+    away: [3, 6]
+sequence22:
+  coat1:
+    home: [3, 5]
+    away: [6, 8]
+  coat2:
+    home: [4, 9]
+    away: [7, 11]
+sequence23:
+  coat1:
+    home: [1, 11]
+    away: [2, 6]
+  coat2:
+    home: [3, 10]
+    away: [5, 8]
+sequence24:
+  coat1:
+    home: [7, 10]
+    away: [9, 12]
+  coat2:
+    home: [4, 11]
+    away: [5, 12]
+sequence25:
+  coat1:
+    home: [1, 2]
+    away: [9, 10]
+  coat2:
+    home: [3, 4]
+    away: [5, 7]
+sequence26:
+  coat1:
+    home: [1, 5]
+    away: [4, 8]
+  coat2:
+    home: [2, 11]
+    away: [6, 9]
+sequence27:
+  coat1:
+    home: [1, 3]
+    away: [6, 12]
+  coat2:
+    home: [2, 4]
+    away: [7, 8]
+sequence28:
+  coat1:
+    home: [1, 7]
+    away: [3, 11]
+  coat2:
+    home: [2, 9]
+    away: [5, 6]
+sequence29:
+  coat1:
+    home: [1, 6]
+    away: [4, 9]
+  coat2:
+    home: [2, 3]
+    away: [8, 10]
+sequence30:
+  coat1:
+    home: [1, 8]
+    away: [3, 9]
+  coat2:
+    home: [2, 5]
+    away: [7, 10]

--- a/config/random_number_table/doubles/coat2_player13.yml
+++ b/config/random_number_table/doubles/coat2_player13.yml
@@ -1,0 +1,211 @@
+# コート2面、プレイヤー13人
+sequence1:
+  coat1:
+    home: [1, 2]
+    away: [3, 4]
+  coat2:
+    home: [5, 6]
+    away: [7, 8]
+sequence2:
+  coat1:
+    home: [9, 10]
+    away: [11, 12]
+  coat2:
+    home: [1, 5]
+    away: [3, 13]
+sequence3:
+  coat1:
+    home: [2, 7]
+    away: [4, 9]
+  coat2:
+    home: [6, 11]
+    away: [8, 10]
+sequence4:
+  coat1:
+    home: [1, 3]
+    away: [5, 9]
+  coat2:
+    home: [2, 12]
+    away: [7, 13]
+sequence5:
+  coat1:
+    home: [4, 6]
+    away: [8, 11]
+  coat2:
+    home: [3, 10]
+    away: [5, 12]
+sequence6:
+  coat1:
+    home: [1, 7]
+    away: [2, 8]
+  coat2:
+    home: [9, 13]
+    away: [4, 10]
+sequence7:
+  coat1:
+    home: [3, 6]
+    away: [5, 11]
+  coat2:
+    home: [2, 9]
+    away: [12, 13]
+sequence8:
+  coat1:
+    home: [1, 4]
+    away: [7, 10]
+  coat2:
+    home: [8, 12]
+    away: [6, 9]
+sequence9:
+  coat1:
+    home: [2, 5]
+    away: [3, 8]
+  coat2:
+    home: [11, 13]
+    away: [1, 6]
+sequence10:
+  coat1:
+    home: [4, 7]
+    away: [9, 12]
+  coat2:
+    home: [10, 11]
+    away: [5, 13]
+sequence11:
+  coat1:
+    home: [1, 8]
+    away: [2, 11]
+  coat2:
+    home: [3, 9]
+    away: [6, 7]
+sequence12:
+  coat1:
+    home: [5, 10]
+    away: [4, 13]
+  coat2:
+    home: [12, 11]
+    away: [1, 9]
+sequence13:
+  coat1:
+    home: [2, 6]
+    away: [3, 12]
+  coat2:
+    home: [7, 8]
+    away: [5, 4]
+sequence14:
+  coat1:
+    home: [1, 10]
+    away: [11, 13]
+  coat2:
+    home: [9, 6]
+    away: [2, 3]
+sequence15:
+  coat1:
+    home: [4, 8]
+    away: [5, 7]
+  coat2:
+    home: [12, 10]
+    away: [1, 11]
+sequence16:
+  coat1:
+    home: [2, 13]
+    away: [3, 5]
+  coat2:
+    home: [6, 8]
+    away: [9, 7]
+sequence17:
+  coat1:
+    home: [1, 12]
+    away: [4, 11]
+  coat2:
+    home: [10, 13]
+    away: [2, 5]
+sequence18:
+  coat1:
+    home: [3, 7]
+    away: [6, 10]
+  coat2:
+    home: [8, 9]
+    away: [1, 4]
+sequence19:
+  coat1:
+    home: [5, 11]
+    away: [2, 12]
+  coat2:
+    home: [13, 7]
+    away: [3, 8]
+sequence20:
+  coat1:
+    home: [1, 6]
+    away: [9, 10]
+  coat2:
+    home: [4, 5]
+    away: [11, 12]
+sequence21:
+  coat1:
+    home: [2, 7]
+    away: [3, 13]
+  coat2:
+    home: [8, 10]
+    away: [6, 11]
+sequence22:
+  coat1:
+    home: [1, 5]
+    away: [7, 9]
+  coat2:
+    home: [4, 12]
+    away: [3, 6]
+sequence23:
+  coat1:
+    home: [2, 8]
+    away: [11, 13]
+  coat2:
+    home: [10, 5]
+    away: [1, 7]
+sequence24:
+  coat1:
+    home: [3, 9]
+    away: [4, 13]
+  coat2:
+    home: [6, 12]
+    away: [8, 11]
+sequence25:
+  coat1:
+    home: [1, 10]
+    away: [2, 4]
+  coat2:
+    home: [5, 7]
+    away: [9, 12]
+sequence26:
+  coat1:
+    home: [3, 11]
+    away: [6, 13]
+  coat2:
+    home: [8, 5]
+    away: [1, 2]
+sequence27:
+  coat1:
+    home: [4, 7]
+    away: [10, 12]
+  coat2:
+    home: [9, 11]
+    away: [3, 5]
+sequence28:
+  coat1:
+    home: [1, 13]
+    away: [6, 8]
+  coat2:
+    home: [2, 9]
+    away: [7, 10]
+sequence29:
+  coat1:
+    home: [3, 4]
+    away: [11, 12]
+  coat2:
+    home: [5, 6]
+    away: [1, 8]
+sequence30:
+  coat1:
+    home: [2, 10]
+    away: [13, 9]
+  coat2:
+    home: [7, 11]
+    away: [4, 5]

--- a/config/random_number_table/doubles/coat2_player14.yml
+++ b/config/random_number_table/doubles/coat2_player14.yml
@@ -1,0 +1,211 @@
+# コート2面、プレイヤー14人
+sequence1:
+  coat1:
+    home: [1, 2]
+    away: [3, 4]
+  coat2:
+    home: [5, 6]
+    away: [7, 8]
+sequence2:
+  coat1:
+    home: [9, 10]
+    away: [11, 12]
+  coat2:
+    home: [13, 14]
+    away: [1, 5]
+sequence3:
+  coat1:
+    home: [2, 6]
+    away: [3, 9]
+  coat2:
+    home: [4, 7]
+    away: [10, 13]
+sequence4:
+  coat1:
+    home: [8, 11]
+    away: [12, 14]
+  coat2:
+    home: [1, 3]
+    away: [5, 9]
+sequence5:
+  coat1:
+    home: [2, 7]
+    away: [4, 10]
+  coat2:
+    home: [6, 12]
+    away: [8, 13]
+sequence6:
+  coat1:
+    home: [1, 11]
+    away: [5, 14]
+  coat2:
+    home: [3, 7]
+    away: [9, 12]
+sequence7:
+  coat1:
+    home: [2, 8]
+    away: [4, 11]
+  coat2:
+    home: [6, 10]
+    away: [13, 14]
+sequence8:
+  coat1:
+    home: [1, 12]
+    away: [3, 8]
+  coat2:
+    home: [5, 7]
+    away: [9, 11]
+sequence9:
+  coat1:
+    home: [2, 13]
+    away: [4, 12]
+  coat2:
+    home: [6, 9]
+    away: [10, 14]
+sequence10:
+  coat1:
+    home: [1, 4]
+    away: [7, 13]
+  coat2:
+    home: [3, 11]
+    away: [5, 8]
+sequence11:
+  coat1:
+    home: [2, 9]
+    away: [6, 11]
+  coat2:
+    home: [10, 12]
+    away: [1, 14]
+sequence12:
+  coat1:
+    home: [3, 5]
+    away: [7, 12]
+  coat2:
+    home: [4, 8]
+    away: [9, 13]
+sequence13:
+  coat1:
+    home: [1, 6]
+    away: [10, 11]
+  coat2:
+    home: [2, 5]
+    away: [14, 7]
+sequence14:
+  coat1:
+    home: [3, 13]
+    away: [4, 9]
+  coat2:
+    home: [8, 12]
+    away: [6, 14]
+sequence15:
+  coat1:
+    home: [1, 10]
+    away: [5, 13]
+  coat2:
+    home: [2, 11]
+    away: [7, 9]
+sequence16:
+  coat1:
+    home: [3, 14]
+    away: [4, 6]
+  coat2:
+    home: [8, 10]
+    away: [12, 13]
+sequence17:
+  coat1:
+    home: [1, 7]
+    away: [11, 12]
+  coat2:
+    home: [2, 4]
+    away: [5, 6]
+sequence18:
+  coat1:
+    home: [9, 14]
+    away: [3, 10]
+  coat2:
+    home: [8, 13]
+    away: [1, 9]
+sequence19:
+  coat1:
+    home: [2, 12]
+    away: [5, 11]
+  coat2:
+    home: [6, 7]
+    away: [4, 14]
+sequence20:
+  coat1:
+    home: [1, 8]
+    away: [10, 13]
+  coat2:
+    home: [3, 12]
+    away: [9, 11]
+sequence21:
+  coat1:
+    home: [2, 14]
+    away: [5, 7]
+  coat2:
+    home: [4, 13]
+    away: [6, 8]
+sequence22:
+  coat1:
+    home: [1, 3]
+    away: [11, 14]
+  coat2:
+    home: [9, 10]
+    away: [12, 7]
+sequence23:
+  coat1:
+    home: [2, 6]
+    away: [8, 11]
+  coat2:
+    home: [4, 5]
+    away: [13, 9]
+sequence24:
+  coat1:
+    home: [1, 13]
+    away: [3, 6]
+  coat2:
+    home: [7, 10]
+    away: [12, 14]
+sequence25:
+  coat1:
+    home: [2, 9]
+    away: [4, 7]
+  coat2:
+    home: [5, 8]
+    away: [11, 13]
+sequence26:
+  coat1:
+    home: [1, 12]
+    away: [6, 9]
+  coat2:
+    home: [3, 4]
+    away: [10, 14]
+sequence27:
+  coat1:
+    home: [2, 10]
+    away: [5, 12]
+  coat2:
+    home: [7, 13]
+    away: [8, 9]
+sequence28:
+  coat1:
+    home: [1, 11]
+    away: [4, 6]
+  coat2:
+    home: [3, 5]
+    away: [14, 8]
+sequence29:
+  coat1:
+    home: [2, 7]
+    away: [9, 12]
+  coat2:
+    home: [10, 13]
+    away: [1, 4]
+sequence30:
+  coat1:
+    home: [5, 9]
+    away: [6, 10]
+  coat2:
+    home: [11, 14]
+    away: [3, 7]

--- a/config/random_number_table/doubles/coat2_player15.yml
+++ b/config/random_number_table/doubles/coat2_player15.yml
@@ -1,0 +1,211 @@
+# コート2面、プレイヤー15人
+sequence1:
+  coat1:
+    home: [1, 2]
+    away: [3, 4]
+  coat2:
+    home: [5, 6]
+    away: [7, 8]
+sequence2:
+  coat1:
+    home: [9, 10]
+    away: [11, 12]
+  coat2:
+    home: [13, 14]
+    away: [1, 15]
+sequence3:
+  coat1:
+    home: [2, 5]
+    away: [3, 9]
+  coat2:
+    home: [4, 7]
+    away: [10, 13]
+sequence4:
+  coat1:
+    home: [6, 11]
+    away: [12, 14]
+  coat2:
+    home: [8, 15]
+    away: [1, 3]
+sequence5:
+  coat1:
+    home: [2, 7]
+    away: [4, 9]
+  coat2:
+    home: [5, 12]
+    away: [6, 13]
+sequence6:
+  coat1:
+    home: [1, 11]
+    away: [10, 15]
+  coat2:
+    home: [3, 8]
+    away: [14, 7]
+sequence7:
+  coat1:
+    home: [2, 6]
+    away: [4, 11]
+  coat2:
+    home: [5, 9]
+    away: [12, 15]
+sequence8:
+  coat1:
+    home: [1, 13]
+    away: [3, 6]
+  coat2:
+    home: [7, 10]
+    away: [8, 14]
+sequence9:
+  coat1:
+    home: [2, 12]
+    away: [4, 13]
+  coat2:
+    home: [5, 11]
+    away: [9, 15]
+sequence10:
+  coat1:
+    home: [1, 7]
+    away: [6, 12]
+  coat2:
+    home: [3, 5]
+    away: [10, 14]
+sequence11:
+  coat1:
+    home: [2, 8]
+    away: [9, 13]
+  coat2:
+    home: [4, 15]
+    away: [11, 7]
+sequence12:
+  coat1:
+    home: [1, 9]
+    away: [5, 8]
+  coat2:
+    home: [3, 12]
+    away: [6, 10]
+sequence13:
+  coat1:
+    home: [2, 14]
+    away: [4, 5]
+  coat2:
+    home: [7, 13]
+    away: [11, 15]
+sequence14:
+  coat1:
+    home: [1, 6]
+    away: [8, 9]
+  coat2:
+    home: [3, 11]
+    away: [10, 13]
+sequence15:
+  coat1:
+    home: [2, 10]
+    away: [5, 7]
+  coat2:
+    home: [12, 14]
+    away: [1, 4]
+sequence16:
+  coat1:
+    home: [3, 15]
+    away: [6, 11]
+  coat2:
+    home: [8, 13]
+    away: [9, 10]
+sequence17:
+  coat1:
+    home: [1, 5]
+    away: [2, 11]
+  coat2:
+    home: [7, 12]
+    away: [14, 15]
+sequence18:
+  coat1:
+    home: [3, 4]
+    away: [8, 12]
+  coat2:
+    home: [6, 9]
+    away: [13, 5]
+sequence19:
+  coat1:
+    home: [1, 10]
+    away: [7, 11]
+  coat2:
+    home: [2, 15]
+    away: [14, 9]
+sequence20:
+  coat1:
+    home: [3, 13]
+    away: [4, 6]
+  coat2:
+    home: [5, 12]
+    away: [8, 10]
+sequence21:
+  coat1:
+    home: [1, 7]
+    away: [9, 12]
+  coat2:
+    home: [2, 3]
+    away: [11, 14]
+sequence22:
+  coat1:
+    home: [4, 5]
+    away: [10, 15]
+  coat2:
+    home: [6, 8]
+    away: [13, 7]
+sequence23:
+  coat1:
+    home: [1, 14]
+    away: [3, 9]
+  coat2:
+    home: [2, 12]
+    away: [5, 11]
+sequence24:
+  coat1:
+    home: [4, 8]
+    away: [6, 15]
+  coat2:
+    home: [10, 13]
+    away: [7, 9]
+sequence25:
+  coat1:
+    home: [1, 11]
+    away: [2, 4]
+  coat2:
+    home: [3, 5]
+    away: [12, 15]
+sequence26:
+  coat1:
+    home: [6, 7]
+    away: [8, 14]
+  coat2:
+    home: [9, 10]
+    away: [13, 11]
+sequence27:
+  coat1:
+    home: [1, 12]
+    away: [2, 13]
+  coat2:
+    home: [3, 7]
+    away: [4, 10]
+sequence28:
+  coat1:
+    home: [5, 9]
+    away: [6, 14]
+  coat2:
+    home: [8, 15]
+    away: [11, 12]
+sequence29:
+  coat1:
+    home: [1, 3]
+    away: [9, 14]
+  coat2:
+    home: [2, 6]
+    away: [7, 15]
+sequence30:
+  coat1:
+    home: [4, 11]
+    away: [5, 13]
+  coat2:
+    home: [10, 12]
+    away: [8, 9]

--- a/config/random_number_table/doubles/coat2_player16.yml
+++ b/config/random_number_table/doubles/coat2_player16.yml
@@ -1,0 +1,211 @@
+# コート2面、プレイヤー16人
+sequence1:
+  coat1:
+    home: [1, 2]
+    away: [3, 4]
+  coat2:
+    home: [5, 6]
+    away: [7, 8]
+sequence2:
+  coat1:
+    home: [9, 10]
+    away: [11, 12]
+  coat2:
+    home: [13, 14]
+    away: [15, 16]
+sequence3:
+  coat1:
+    home: [1, 5]
+    away: [2, 6]
+  coat2:
+    home: [3, 7]
+    away: [4, 8]
+sequence4:
+  coat1:
+    home: [9, 13]
+    away: [10, 14]
+  coat2:
+    home: [11, 15]
+    away: [12, 16]
+sequence5:
+  coat1:
+    home: [1, 9]
+    away: [2, 10]
+  coat2:
+    home: [3, 11]
+    away: [4, 12]
+sequence6:
+  coat1:
+    home: [5, 13]
+    away: [6, 14]
+  coat2:
+    home: [7, 15]
+    away: [8, 16]
+sequence7:
+  coat1:
+    home: [1, 3]
+    away: [2, 4]
+  coat2:
+    home: [5, 7]
+    away: [6, 8]
+sequence8:
+  coat1:
+    home: [9, 11]
+    away: [10, 12]
+  coat2:
+    home: [13, 15]
+    away: [14, 16]
+sequence9:
+  coat1:
+    home: [1, 13]
+    away: [2, 14]
+  coat2:
+    home: [3, 15]
+    away: [4, 16]
+sequence10:
+  coat1:
+    home: [5, 9]
+    away: [6, 10]
+  coat2:
+    home: [7, 11]
+    away: [8, 12]
+sequence11:
+  coat1:
+    home: [1, 7]
+    away: [2, 8]
+  coat2:
+    home: [3, 5]
+    away: [4, 6]
+sequence12:
+  coat1:
+    home: [9, 15]
+    away: [10, 16]
+  coat2:
+    home: [11, 13]
+    away: [12, 14]
+sequence13:
+  coat1:
+    home: [1, 11]
+    away: [2, 12]
+  coat2:
+    home: [3, 9]
+    away: [4, 10]
+sequence14:
+  coat1:
+    home: [5, 15]
+    away: [6, 16]
+  coat2:
+    home: [7, 13]
+    away: [8, 14]
+sequence15:
+  coat1:
+    home: [1, 15]
+    away: [2, 16]
+  coat2:
+    home: [3, 13]
+    away: [4, 14]
+sequence16:
+  coat1:
+    home: [5, 11]
+    away: [6, 12]
+  coat2:
+    home: [7, 9]
+    away: [8, 10]
+sequence17:
+  coat1:
+    home: [1, 6]
+    away: [2, 5]
+  coat2:
+    home: [3, 8]
+    away: [4, 7]
+sequence18:
+  coat1:
+    home: [9, 14]
+    away: [10, 13]
+  coat2:
+    home: [11, 16]
+    away: [12, 15]
+sequence19:
+  coat1:
+    home: [1, 10]
+    away: [2, 9]
+  coat2:
+    home: [3, 12]
+    away: [4, 11]
+sequence20:
+  coat1:
+    home: [5, 16]
+    away: [6, 15]
+  coat2:
+    home: [7, 14]
+    away: [8, 13]
+sequence21:
+  coat1:
+    home: [1, 12]
+    away: [2, 11]
+  coat2:
+    home: [3, 14]
+    away: [4, 13]
+sequence22:
+  coat1:
+    home: [5, 10]
+    away: [6, 9]
+  coat2:
+    home: [7, 16]
+    away: [8, 15]
+sequence23:
+  coat1:
+    home: [1, 14]
+    away: [2, 13]
+  coat2:
+    home: [3, 16]
+    away: [4, 15]
+sequence24:
+  coat1:
+    home: [5, 12]
+    away: [6, 11]
+  coat2:
+    home: [7, 10]
+    away: [8, 9]
+sequence25:
+  coat1:
+    home: [1, 16]
+    away: [2, 15]
+  coat2:
+    home: [3, 10]
+    away: [4, 9]
+sequence26:
+  coat1:
+    home: [5, 14]
+    away: [6, 13]
+  coat2:
+    home: [7, 12]
+    away: [8, 11]
+sequence27:
+  coat1:
+    home: [1, 8]
+    away: [2, 7]
+  coat2:
+    home: [3, 6]
+    away: [4, 5]
+sequence28:
+  coat1:
+    home: [9, 16]
+    away: [10, 15]
+  coat2:
+    home: [11, 14]
+    away: [12, 13]
+sequence29:
+  coat1:
+    home: [1, 4]
+    away: [2, 3]
+  coat2:
+    home: [5, 8]
+    away: [6, 7]
+sequence30:
+  coat1:
+    home: [9, 12]
+    away: [10, 11]
+  coat2:
+    home: [13, 16]
+    away: [14, 15]

--- a/config/random_number_table/doubles/coat2_player8.yml
+++ b/config/random_number_table/doubles/coat2_player8.yml
@@ -1,0 +1,197 @@
+# コート2面、プレイヤー8人
+sequence1:
+  coat1:
+    home: [1, 2]
+    away: [3, 4]
+  coat2:
+    home: [5, 6]
+    away: [7, 8]
+sequence2:
+  coat1:
+    home: [1, 5]
+    away: [2, 6]
+  coat2:
+    home: [3, 7]
+    away: [4, 8]
+sequence3:
+  coat1:
+    home: [1, 3]
+    away: [5, 7]
+  coat2:
+    home: [2, 4]
+    away: [6, 8]
+sequence4:
+  coat1:
+    home: [1, 7]
+    away: [2, 8]
+  coat2:
+    home: [3, 5]
+    away: [4, 6]
+sequence5:
+  coat1:
+    home: [1, 6]
+    away: [2, 5]
+  coat2:
+    home: [3, 8]
+    away: [4, 7]
+sequence6:
+  coat1:
+    home: [1, 4]
+    away: [5, 8]
+  coat2:
+    home: [2, 3]
+    away: [6, 7]
+sequence7:
+  coat1:
+    home: [1, 8]
+    away: [2, 7]
+  coat2:
+    home: [3, 6]
+    away: [4, 5]
+sequence8:
+  coat1:
+    home: [1, 2]
+    away: [5, 6]
+  coat2:
+    home: [3, 4]
+    away: [7, 8]
+sequence9:
+  coat1:
+    home: [1, 5]
+    away: [3, 7]
+  coat2:
+    home: [2, 6]
+    away: [4, 8]
+sequence10:
+  coat1:
+    home: [1, 3]
+    away: [2, 4]
+  coat2:
+    home: [5, 7]
+    away: [6, 8]
+sequence11:
+  coat1:
+    home: [1, 7]
+    away: [4, 6]
+  coat2:
+    home: [2, 8]
+    away: [3, 5]
+sequence12:
+  coat1:
+    home: [1, 6]
+    away: [3, 8]
+  coat2:
+    home: [2, 5]
+    away: [4, 7]
+sequence13:
+  coat1:
+    home: [1, 4]
+    away: [6, 7]
+  coat2:
+    home: [2, 3]
+    away: [5, 8]
+sequence14:
+  coat1:
+    home: [1, 8]
+    away: [4, 5]
+  coat2:
+    home: [2, 7]
+    away: [3, 6]
+sequence15:
+  coat1:
+    home: [1, 2]
+    away: [7, 8]
+  coat2:
+    home: [3, 4]
+    away: [5, 6]
+sequence16:
+  coat1:
+    home: [1, 5]
+    away: [4, 8]
+  coat2:
+    home: [2, 6]
+    away: [3, 7]
+sequence17:
+  coat1:
+    home: [1, 3]
+    away: [6, 8]
+  coat2:
+    home: [2, 4]
+    away: [5, 7]
+sequence18:
+  coat1:
+    home: [1, 7]
+    away: [3, 5]
+  coat2:
+    home: [2, 8]
+    away: [4, 6]
+sequence19:
+  coat1:
+    home: [1, 6]
+    away: [4, 7]
+  coat2:
+    home: [2, 5]
+    away: [3, 8]
+sequence20:
+  coat1:
+    home: [1, 4]
+    away: [2, 3]
+  coat2:
+    home: [5, 8]
+    away: [6, 7]
+sequence21:
+  coat1:
+    home: [1, 8]
+    away: [3, 6]
+  coat2:
+    home: [2, 7]
+    away: [4, 5]
+sequence22:
+  coat1:
+    home: [1, 2]
+    away: [5, 6]
+  coat2:
+    home: [3, 4]
+    away: [7, 8]
+sequence23:
+  coat1:
+    home: [1, 5]
+    away: [2, 6]
+  coat2:
+    home: [3, 7]
+    away: [4, 8]
+sequence24:
+  coat1:
+    home: [1, 3]
+    away: [5, 7]
+  coat2:
+    home: [2, 4]
+    away: [6, 8]
+sequence25:
+  coat1:
+    home: [1, 7]
+    away: [2, 8]
+  coat2:
+    home: [3, 5]
+    away: [4, 6]
+sequence26:
+  coat1:
+    home: [1, 6]
+    away: [2, 5]
+  coat2:
+    home: [3, 8]
+    away: [4, 7]
+sequence27:
+  coat1:
+    home: [1, 4]
+    away: [5, 8]
+  coat2:
+    home: [2, 3]
+    away: [6, 7]
+sequence28:
+  coat1:
+    home: [1, 8]
+    away: [2, 7]
+  coat2:
+    home: [3, 6]
+    away: [4, 5]

--- a/config/random_number_table/doubles/coat2_player9.yml
+++ b/config/random_number_table/doubles/coat2_player9.yml
@@ -1,0 +1,211 @@
+# コート2面、プレイヤー9人
+sequence1:
+  coat1:
+    home: [1, 2]
+    away: [3, 4]
+  coat2:
+    home: [5, 6]
+    away: [7, 8]
+sequence2:
+  coat1:
+    home: [1, 5]
+    away: [2, 9]
+  coat2:
+    home: [3, 7]
+    away: [4, 6]
+sequence3:
+  coat1:
+    home: [1, 3]
+    away: [5, 9]
+  coat2:
+    home: [2, 8]
+    away: [6, 7]
+sequence4:
+  coat1:
+    home: [1, 7]
+    away: [2, 4]
+  coat2:
+    home: [3, 5]
+    away: [8, 9]
+sequence5:
+  coat1:
+    home: [1, 6]
+    away: [2, 3]
+  coat2:
+    home: [4, 9]
+    away: [7, 8]
+sequence6:
+  coat1:
+    home: [1, 8]
+    away: [2, 5]
+  coat2:
+    home: [3, 9]
+    away: [6, 7]
+sequence7:
+  coat1:
+    home: [1, 4]
+    away: [5, 7]
+  coat2:
+    home: [2, 6]
+    away: [8, 9]
+sequence8:
+  coat1:
+    home: [1, 9]
+    away: [3, 8]
+  coat2:
+    home: [4, 5]
+    away: [6, 2]
+sequence9:
+  coat1:
+    home: [2, 7]
+    away: [3, 6]
+  coat2:
+    home: [4, 8]
+    away: [5, 9]
+sequence10:
+  coat1:
+    home: [1, 2]
+    away: [5, 6]
+  coat2:
+    home: [3, 4]
+    away: [7, 9]
+sequence11:
+  coat1:
+    home: [1, 5]
+    away: [3, 7]
+  coat2:
+    home: [2, 9]
+    away: [6, 8]
+sequence12:
+  coat1:
+    home: [1, 3]
+    away: [2, 8]
+  coat2:
+    home: [4, 9]
+    away: [5, 7]
+sequence13:
+  coat1:
+    home: [1, 7]
+    away: [6, 9]
+  coat2:
+    home: [2, 4]
+    away: [3, 5]
+sequence14:
+  coat1:
+    home: [1, 6]
+    away: [4, 8]
+  coat2:
+    home: [2, 3]
+    away: [7, 9]
+sequence15:
+  coat1:
+    home: [1, 8]
+    away: [3, 9]
+  coat2:
+    home: [5, 6]
+    away: [2, 7]
+sequence16:
+  coat1:
+    home: [1, 4]
+    away: [6, 7]
+  coat2:
+    home: [2, 5]
+    away: [8, 9]
+sequence17:
+  coat1:
+    home: [1, 9]
+    away: [4, 5]
+  coat2:
+    home: [3, 8]
+    away: [6, 7]
+sequence18:
+  coat1:
+    home: [2, 6]
+    away: [3, 9]
+  coat2:
+    home: [4, 7]
+    away: [5, 8]
+sequence19:
+  coat1:
+    home: [1, 2]
+    away: [7, 8]
+  coat2:
+    home: [3, 4]
+    away: [5, 6]
+sequence20:
+  coat1:
+    home: [1, 5]
+    away: [4, 9]
+  coat2:
+    home: [2, 3]
+    away: [6, 8]
+sequence21:
+  coat1:
+    home: [1, 3]
+    away: [6, 9]
+  coat2:
+    home: [2, 7]
+    away: [4, 8]
+sequence22:
+  coat1:
+    home: [1, 7]
+    away: [3, 5]
+  coat2:
+    home: [2, 9]
+    away: [6, 8]
+sequence23:
+  coat1:
+    home: [1, 6]
+    away: [5, 9]
+  coat2:
+    home: [3, 7]
+    away: [4, 2]
+sequence24:
+  coat1:
+    home: [1, 8]
+    away: [4, 6]
+  coat2:
+    home: [2, 5]
+    away: [7, 9]
+sequence25:
+  coat1:
+    home: [1, 4]
+    away: [2, 9]
+  coat2:
+    home: [3, 6]
+    away: [5, 8]
+sequence26:
+  coat1:
+    home: [1, 9]
+    away: [2, 8]
+  coat2:
+    home: [4, 5]
+    away: [3, 7]
+sequence27:
+  coat1:
+    home: [2, 6]
+    away: [4, 9]
+  coat2:
+    home: [3, 5]
+    away: [7, 8]
+sequence28:
+  coat1:
+    home: [1, 2]
+    away: [5, 7]
+  coat2:
+    home: [3, 8]
+    away: [4, 6]
+sequence29:
+  coat1:
+    home: [1, 5]
+    away: [6, 8]
+  coat2:
+    home: [2, 3]
+    away: [7, 9]
+sequence30:
+  coat1:
+    home: [1, 3]
+    away: [4, 7]
+  coat2:
+    home: [2, 6]
+    away: [5, 9]

--- a/config/random_number_table/singles/coat1_player2.yml
+++ b/config/random_number_table/singles/coat1_player2.yml
@@ -1,0 +1,5 @@
+# コート1面、プレイヤー2人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]

--- a/config/random_number_table/singles/coat1_player3.yml
+++ b/config/random_number_table/singles/coat1_player3.yml
@@ -1,0 +1,13 @@
+# コート1面、プレイヤー3人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+sequence2:
+  coat1:
+    home: [3]
+    away: [1]
+sequence3:
+  coat1:
+    home: [2]
+    away: [3]

--- a/config/random_number_table/singles/coat1_player4.yml
+++ b/config/random_number_table/singles/coat1_player4.yml
@@ -1,0 +1,25 @@
+# コート1面、プレイヤー4人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+sequence2:
+  coat1:
+    home: [3]
+    away: [4]
+sequence3:
+  coat1:
+    home: [1]
+    away: [3]
+sequence4:
+  coat1:
+    home: [2]
+    away: [4]
+sequence5:
+  coat1:
+    home: [1]
+    away: [4]
+sequence6:
+  coat1:
+    home: [3]
+    away: [2]

--- a/config/random_number_table/singles/coat1_player5.yml
+++ b/config/random_number_table/singles/coat1_player5.yml
@@ -1,0 +1,41 @@
+# コート1面、プレイヤー5人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+sequence2:
+  coat1:
+    home: [3]
+    away: [4]
+sequence3:
+  coat1:
+    home: [5]
+    away: [1]
+sequence4:
+  coat1:
+    home: [2]
+    away: [3]
+sequence5:
+  coat1:
+    home: [4]
+    away: [5]
+sequence6:
+  coat1:
+    home: [1]
+    away: [3]
+sequence7:
+  coat1:
+    home: [2]
+    away: [4]
+sequence8:
+  coat1:
+    home: [5]
+    away: [3]
+sequence9:
+  coat1:
+    home: [1]
+    away: [4]
+sequence10:
+  coat1:
+    home: [2]
+    away: [5]

--- a/config/random_number_table/singles/coat1_player6.yml
+++ b/config/random_number_table/singles/coat1_player6.yml
@@ -1,0 +1,49 @@
+# コート1面、プレイヤー6人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+sequence2:
+  coat1:
+    home: [3]
+    away: [4]
+sequence3:
+  coat1:
+    home: [5]
+    away: [6]
+sequence4:
+  coat1:
+    home: [1]
+    away: [3]
+sequence5:
+  coat1:
+    home: [2]
+    away: [4]
+sequence6:
+  coat1:
+    home: [5]
+    away: [1]
+sequence7:
+  coat1:
+    home: [6]
+    away: [2]
+sequence8:
+  coat1:
+    home: [4]
+    away: [6]
+sequence9:
+  coat1:
+    home: [3]
+    away: [5]
+sequence10:
+  coat1:
+    home: [1]
+    away: [4]
+sequence11:
+  coat1:
+    home: [2]
+    away: [6]
+sequence12:
+  coat1:
+    home: [5]
+    away: [3]

--- a/config/random_number_table/singles/coat1_player7.yml
+++ b/config/random_number_table/singles/coat1_player7.yml
@@ -1,0 +1,85 @@
+# コート1面、プレイヤー7人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+sequence2:
+  coat1:
+    home: [3]
+    away: [4]
+sequence3:
+  coat1:
+    home: [5]
+    away: [6]
+sequence4:
+  coat1:
+    home: [7]
+    away: [1]
+sequence5:
+  coat1:
+    home: [2]
+    away: [3]
+sequence6:
+  coat1:
+    home: [4]
+    away: [5]
+sequence7:
+  coat1:
+    home: [6]
+    away: [7]
+sequence8:
+  coat1:
+    home: [1]
+    away: [3]
+sequence9:
+  coat1:
+    home: [2]
+    away: [4]
+sequence10:
+  coat1:
+    home: [5]
+    away: [7]
+sequence11:
+  coat1:
+    home: [6]
+    away: [1]
+sequence12:
+  coat1:
+    home: [3]
+    away: [5]
+sequence13:
+  coat1:
+    home: [4]
+    away: [6]
+sequence14:
+  coat1:
+    home: [7]
+    away: [2]
+sequence15:
+  coat1:
+    home: [1]
+    away: [4]
+sequence16:
+  coat1:
+    home: [3]
+    away: [6]
+sequence17:
+  coat1:
+    home: [2]
+    away: [5]
+sequence18:
+  coat1:
+    home: [7]
+    away: [3]
+sequence19:
+  coat1:
+    home: [4]
+    away: [1]
+sequence20:
+  coat1:
+    home: [6]
+    away: [2]
+sequence21:
+  coat1:
+    home: [5]
+    away: [7]

--- a/config/random_number_table/singles/coat1_player8.yml
+++ b/config/random_number_table/singles/coat1_player8.yml
@@ -1,0 +1,113 @@
+# コート1面、プレイヤー8人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+sequence2:
+  coat1:
+    home: [3]
+    away: [4]
+sequence3:
+  coat1:
+    home: [5]
+    away: [6]
+sequence4:
+  coat1:
+    home: [7]
+    away: [8]
+sequence5:
+  coat1:
+    home: [1]
+    away: [3]
+sequence6:
+  coat1:
+    home: [2]
+    away: [4]
+sequence7:
+  coat1:
+    home: [5]
+    away: [7]
+sequence8:
+  coat1:
+    home: [6]
+    away: [8]
+sequence9:
+  coat1:
+    home: [1]
+    away: [4]
+sequence10:
+  coat1:
+    home: [2]
+    away: [3]
+sequence11:
+  coat1:
+    home: [5]
+    away: [8]
+sequence12:
+  coat1:
+    home: [6]
+    away: [7]
+sequence13:
+  coat1:
+    home: [1]
+    away: [5]
+sequence14:
+  coat1:
+    home: [2]
+    away: [6]
+sequence15:
+  coat1:
+    home: [3]
+    away: [7]
+sequence16:
+  coat1:
+    home: [4]
+    away: [8]
+sequence17:
+  coat1:
+    home: [1]
+    away: [6]
+sequence18:
+  coat1:
+    home: [2]
+    away: [7]
+sequence19:
+  coat1:
+    home: [3]
+    away: [8]
+sequence20:
+  coat1:
+    home: [4]
+    away: [5]
+sequence21:
+  coat1:
+    home: [1]
+    away: [7]
+sequence22:
+  coat1:
+    home: [2]
+    away: [8]
+sequence23:
+  coat1:
+    home: [3]
+    away: [5]
+sequence24:
+  coat1:
+    home: [4]
+    away: [6]
+sequence25:
+  coat1:
+    home: [1]
+    away: [8]
+sequence26:
+  coat1:
+    home: [2]
+    away: [5]
+sequence27:
+  coat1:
+    home: [3]
+    away: [6]
+sequence28:
+  coat1:
+    home: [4]
+    away: [7]

--- a/config/random_number_table/singles/coat2_player10.yml
+++ b/config/random_number_table/singles/coat2_player10.yml
@@ -1,0 +1,162 @@
+# コート2面、プレイヤー10人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+  coat2:
+    home: [3]
+    away: [4]
+sequence2:
+  coat1:
+    home: [5]
+    away: [6]
+  coat2:
+    home: [7]
+    away: [8]
+sequence3:
+  coat1:
+    home: [9]
+    away: [10]
+  coat2:
+    home: [1]
+    away: [3]
+sequence4:
+  coat1:
+    home: [2]
+    away: [4]
+  coat2:
+    home: [5]
+    away: [7]
+sequence5:
+  coat1:
+    home: [6]
+    away: [8]
+  coat2:
+    home: [9]
+    away: [1]
+sequence6:
+  coat1:
+    home: [10]
+    away: [3]
+  coat2:
+    home: [2]
+    away: [5]
+sequence7:
+  coat1:
+    home: [4]
+    away: [7]
+  coat2:
+    home: [6]
+    away: [9]
+sequence8:
+  coat1:
+    home: [8]
+    away: [10]
+  coat2:
+    home: [1]
+    away: [5]
+sequence9:
+  coat1:
+    home: [2]
+    away: [3]
+  coat2:
+    home: [4]
+    away: [6]
+sequence10:
+  coat1:
+    home: [7]
+    away: [9]
+  coat2:
+    home: [8]
+    away: [1]
+sequence11:
+  coat1:
+    home: [10]
+    away: [5]
+  coat2:
+    home: [2]
+    away: [6]
+sequence12:
+  coat1:
+    home: [3]
+    away: [7]
+  coat2:
+    home: [4]
+    away: [8]
+sequence13:
+  coat1:
+    home: [9]
+    away: [2]
+  coat2:
+    home: [10]
+    away: [1]
+sequence14:
+  coat1:
+    home: [5]
+    away: [3]
+  coat2:
+    home: [6]
+    away: [7]
+sequence15:
+  coat1:
+    home: [4]
+    away: [9]
+  coat2:
+    home: [8]
+    away: [2]
+sequence16:
+  coat1:
+    home: [10]
+    away: [6]
+  coat2:
+    home: [1]
+    away: [7]
+sequence17:
+  coat1:
+    home: [3]
+    away: [8]
+  coat2:
+    home: [5]
+    away: [4]
+sequence18:
+  coat1:
+    home: [10]
+    away: [2]
+  coat2:
+    home: [9]
+    away: [3]
+sequence19:
+  coat1:
+    home: [1]
+    away: [6]
+  coat2:
+    home: [5]
+    away: [8]
+sequence20:
+  coat1:
+    home: [7]
+    away: [10]
+  coat2:
+    home: [4]
+    away: [1]
+sequence21:
+  coat1:
+    home: [9]
+    away: [5]
+  coat2:
+    home: [3]
+    away: [6]
+sequence22:
+  coat1:
+    home: [2]
+    away: [7]
+  coat2:
+    home: [4]
+    away: [10]
+sequence23:
+  coat1:
+    home: [8]
+    away: [9]
+  coat2:
+    home: [1]
+    away: [3]

--- a/config/random_number_table/singles/coat2_player11.yml
+++ b/config/random_number_table/singles/coat2_player11.yml
@@ -1,0 +1,197 @@
+# コート2面、プレイヤー11人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+  coat2:
+    home: [3]
+    away: [4]
+sequence2:
+  coat1:
+    home: [5]
+    away: [6]
+  coat2:
+    home: [7]
+    away: [8]
+sequence3:
+  coat1:
+    home: [9]
+    away: [10]
+  coat2:
+    home: [11]
+    away: [1]
+sequence4:
+  coat1:
+    home: [2]
+    away: [3]
+  coat2:
+    home: [4]
+    away: [5]
+sequence5:
+  coat1:
+    home: [6]
+    away: [7]
+  coat2:
+    home: [8]
+    away: [9]
+sequence6:
+  coat1:
+    home: [10]
+    away: [11]
+  coat2:
+    home: [1]
+    away: [3]
+sequence7:
+  coat1:
+    home: [2]
+    away: [4]
+  coat2:
+    home: [5]
+    away: [7]
+sequence8:
+  coat1:
+    home: [6]
+    away: [8]
+  coat2:
+    home: [9]
+    away: [11]
+sequence9:
+  coat1:
+    home: [10]
+    away: [1]
+  coat2:
+    home: [3]
+    away: [5]
+sequence10:
+  coat1:
+    home: [2]
+    away: [7]
+  coat2:
+    home: [4]
+    away: [6]
+  sequence11:
+    coat1:
+      home: [8]
+      away: [11]
+    coat2:
+      home: [9]
+      away: [1]
+  sequence12:
+    coat1:
+      home: [10]
+      away: [3]
+    coat2:
+      home: [5]
+      away: [2]
+  sequence13:
+    coat1:
+      home: [4]
+      away: [7]
+    coat2:
+      home: [6]
+      away: [9]
+  sequence14:
+    coat1:
+      home: [8]
+      away: [10]
+    coat2:
+      home: [11]
+      away: [2]
+  sequence15:
+    coat1:
+      home: [1]
+      away: [5]
+    coat2:
+      home: [3]
+      away: [6]
+  sequence16:
+    coat1:
+      home: [4]
+      away: [9]
+    coat2:
+      home: [7]
+      away: [10]
+  sequence17:
+    coat1:
+      home: [8]
+      away: [2]
+    coat2:
+      home: [11]
+      away: [3]
+  sequence18:
+    coat1:
+      home: [1]
+      away: [6]
+    coat2:
+      home: [5]
+      away: [9]
+  sequence19:
+    coat1:
+      home: [4]
+      away: [10]
+    coat2:
+      home: [7]
+      away: [11]
+  sequence20:
+    coat1:
+      home: [8]
+      away: [3]
+    coat2:
+      home: [2]
+      away: [6]
+  sequence21:
+    coat1:
+      home: [1]
+      away: [4]
+    coat2:
+      home: [5]
+      away: [10]
+  sequence22:
+    coat1:
+      home: [9]
+      away: [7]
+    coat2:
+      home: [11]
+      away: [6]
+  sequence23:
+    coat1:
+      home: [8]
+      away: [1]
+    coat2:
+      home: [2]
+      away: [10]
+  sequence24:
+    coat1:
+      home: [3]
+      away: [7]
+    coat2:
+      home: [4]
+      away: [11]
+  sequence25:
+    coat1:
+      home: [5]
+      away: [8]
+    coat2:
+      home: [9]
+      away: [2]
+  sequence26:
+    coat1:
+      home: [10]
+      away: [6]
+    coat2:
+      home: [1]
+      away: [7]
+  sequence27:
+    coat1:
+      home: [3]
+      away: [9]
+    coat2:
+      home: [4]
+      away: [8]
+  sequence28:
+    coat1:
+      home: [11]
+      away: [5]
+    coat2:
+      home: [2]
+      away: [1]

--- a/config/random_number_table/singles/coat2_player12.yml
+++ b/config/random_number_table/singles/coat2_player12.yml
@@ -1,0 +1,211 @@
+# コート2面、プレイヤー12人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+  coat2:
+    home: [3]
+    away: [4]
+sequence2:
+  coat1:
+    home: [5]
+    away: [6]
+  coat2:
+    home: [7]
+    away: [8]
+sequence3:
+  coat1:
+    home: [9]
+    away: [10]
+  coat2:
+    home: [11]
+    away: [12]
+sequence4:
+  coat1:
+    home: [1]
+    away: [3]
+  coat2:
+    home: [2]
+    away: [4]
+sequence5:
+  coat1:
+    home: [5]
+    away: [7]
+  coat2:
+    home: [6]
+    away: [8]
+sequence6:
+  coat1:
+    home: [9]
+    away: [11]
+  coat2:
+    home: [10]
+    away: [12]
+sequence7:
+  coat1:
+    home: [1]
+    away: [4]
+  coat2:
+    home: [2]
+    away: [3]
+sequence8:
+  coat1:
+    home: [5]
+    away: [8]
+  coat2:
+    home: [6]
+    away: [7]
+sequence9:
+  coat1:
+    home: [9]
+    away: [12]
+  coat2:
+    home: [10]
+    away: [11]
+sequence10:
+  coat1:
+    home: [1]
+    away: [5]
+  coat2:
+    home: [2]
+    away: [6]
+sequence11:
+  coat1:
+    home: [3]
+    away: [7]
+  coat2:
+    home: [4]
+    away: [8]
+sequence12:
+  coat1:
+    home: [9]
+    away: [1]
+  coat2:
+    home: [10]
+    away: [2]
+sequence13:
+  coat1:
+    home: [11]
+    away: [5]
+  coat2:
+    home: [12]
+    away: [6]
+sequence14:
+  coat1:
+    home: [3]
+    away: [8]
+  coat2:
+    home: [4]
+    away: [7]
+sequence15:
+  coat1:
+    home: [9]
+    away: [2]
+  coat2:
+    home: [10]
+    away: [1]
+sequence16:
+  coat1:
+    home: [11]
+    away: [6]
+  coat2:
+    home: [12]
+    away: [5]
+sequence17:
+  coat1:
+    home: [3]
+    away: [9]
+  coat2:
+    home: [4]
+    away: [10]
+sequence18:
+  coat1:
+    home: [7]
+    away: [11]
+  coat2:
+    home: [8]
+    away: [12]
+sequence19:
+  coat1:
+    home: [1]
+    away: [6]
+  coat2:
+    home: [2]
+    away: [5]
+sequence20:
+  coat1:
+    home: [3]
+    away: [10]
+  coat2:
+    home: [4]
+    away: [9]
+sequence21:
+  coat1:
+    home: [7]
+    away: [12]
+  coat2:
+    home: [8]
+    away: [11]
+sequence22:
+  coat1:
+    home: [5]
+    away: [3]
+  coat2:
+    home: [6]
+    away: [4]
+sequence23:
+  coat1:
+    home: [1]
+    away: [7]
+  coat2:
+    home: [2]
+    away: [8]
+sequence24:
+  coat1:
+    home: [9]
+    away: [5]
+  coat2:
+    home: [10]
+    away: [6]
+sequence25:
+  coat1:
+    home: [11]
+    away: [3]
+  coat2:
+    home: [12]
+    away: [4]
+sequence26:
+  coat1:
+    home: [1]
+    away: [8]
+  coat2:
+    home: [2]
+    away: [7]
+sequence27:
+  coat1:
+    home: [9]
+    away: [6]
+  coat2:
+    home: [10]
+    away: [5]
+sequence28:
+  coat1:
+    home: [11]
+    away: [4]
+  coat2:
+    home: [12]
+    away: [3]
+sequence29:
+  coat1:
+    home: [7]
+    away: [9]
+  coat2:
+    home: [8]
+    away: [10]
+sequence30:
+  coat1:
+    home: [1]
+    away: [11]
+  coat2:
+    home: [2]
+    away: [12]

--- a/config/random_number_table/singles/coat2_player13.yml
+++ b/config/random_number_table/singles/coat2_player13.yml
@@ -1,0 +1,211 @@
+# コート2面、プレイヤー13人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+  coat2:
+    home: [3]
+    away: [4]
+sequence2:
+  coat1:
+    home: [5]
+    away: [6]
+  coat2:
+    home: [7]
+    away: [8]
+sequence3:
+  coat1:
+    home: [9]
+    away: [10]
+  coat2:
+    home: [11]
+    away: [12]
+sequence4:
+  coat1:
+    home: [13]
+    away: [1]
+  coat2:
+    home: [2]
+    away: [3]
+sequence5:
+  coat1:
+    home: [4]
+    away: [5]
+  coat2:
+    home: [6]
+    away: [7]
+sequence6:
+  coat1:
+    home: [8]
+    away: [9]
+  coat2:
+    home: [10]
+    away: [11]
+sequence7:
+  coat1:
+    home: [12]
+    away: [13]
+  coat2:
+    home: [1]
+    away: [5]
+sequence8:
+  coat1:
+    home: [2]
+    away: [6]
+  coat2:
+    home: [3]
+    away: [7]
+sequence9:
+  coat1:
+    home: [4]
+    away: [8]
+  coat2:
+    home: [9]
+    away: [13]
+sequence10:
+  coat1:
+    home: [10]
+    away: [12]
+  coat2:
+    home: [11]
+    away: [1]
+sequence11:
+  coat1:
+    home: [2]
+    away: [4]
+  coat2:
+    home: [3]
+    away: [9]
+sequence12:
+  coat1:
+    home: [5]
+    away: [11]
+  coat2:
+    home: [6]
+    away: [12]
+sequence13:
+  coat1:
+    home: [7]
+    away: [13]
+  coat2:
+    home: [8]
+    away: [10]
+sequence14:
+  coat1:
+    home: [1]
+    away: [9]
+  coat2:
+    home: [2]
+    away: [10]
+sequence15:
+  coat1:
+    home: [3]
+    away: [11]
+  coat2:
+    home: [4]
+    away: [12]
+sequence16:
+  coat1:
+    home: [5]
+    away: [13]
+  coat2:
+    home: [6]
+    away: [8]
+sequence17:
+  coat1:
+    home: [7]
+    away: [1]
+  coat2:
+    home: [2]
+    away: [3]
+sequence18:
+  coat1:
+    home: [4]
+    away: [6]
+  coat2:
+    home: [5]
+    away: [9]
+sequence19:
+  coat1:
+    home: [7]
+    away: [11]
+  coat2:
+    home: [8]
+    away: [12]
+sequence20:
+  coat1:
+    home: [10]
+    away: [13]
+  coat2:
+    home: [1]
+    away: [5]
+sequence21:
+  coat1:
+    home: [2]
+    away: [7]
+  coat2:
+    home: [3]
+    away: [10]
+sequence22:
+  coat1:
+    home: [4]
+    away: [11]
+  coat2:
+    home: [6]
+    away: [13]
+sequence23:
+  coat1:
+    home: [8]
+    away: [5]
+  coat2:
+    home: [9]
+    away: [12]
+sequence24:
+  coat1:
+    home: [1]
+    away: [3]
+  coat2:
+    home: [2]
+    away: [6]
+sequence25:
+  coat1:
+    home: [4]
+    away: [10]
+  coat2:
+    home: [7]
+    away: [9]
+sequence26:
+  coat1:
+    home: [5]
+    away: [12]
+  coat2:
+    home: [8]
+    away: [13]
+sequence27:
+  coat1:
+    home: [1]
+    away: [11]
+  coat2:
+    home: [3]
+    away: [7]
+sequence28:
+  coat1:
+    home: [2]
+    away: [9]
+  coat2:
+    home: [4]
+    away: [5]
+sequence29:
+  coat1:
+    home: [6]
+    away: [8]
+  coat2:
+    home: [10]
+    away: [13]
+sequence30:
+  coat1:
+    home: [7]
+    away: [3]
+  coat2:
+    home: [12]
+    away: [11]

--- a/config/random_number_table/singles/coat2_player14.yml
+++ b/config/random_number_table/singles/coat2_player14.yml
@@ -1,0 +1,211 @@
+# コート2面、プレイヤー14人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+  coat2:
+    home: [3]
+    away: [4]
+sequence2:
+  coat1:
+    home: [5]
+    away: [6]
+  coat2:
+    home: [7]
+    away: [8]
+sequence3:
+  coat1:
+    home: [9]
+    away: [10]
+  coat2:
+    home: [11]
+    away: [12]
+sequence4:
+  coat1:
+    home: [13]
+    away: [14]
+  coat2:
+    home: [1]
+    away: [3]
+sequence5:
+  coat1:
+    home: [2]
+    away: [5]
+  coat2:
+    home: [4]
+    away: [7]
+sequence6:
+  coat1:
+    home: [6]
+    away: [9]
+  coat2:
+    home: [8]
+    away: [11]
+sequence7:
+  coat1:
+    home: [10]
+    away: [13]
+  coat2:
+    home: [12]
+    away: [14]
+sequence8:
+  coat1:
+    home: [1]
+    away: [6]
+  coat2:
+    home: [2]
+    away: [7]
+sequence9:
+  coat1:
+    home: [3]
+    away: [8]
+  coat2:
+    home: [4]
+    away: [9]
+sequence10:
+  coat1:
+    home: [5]
+    away: [10]
+  coat2:
+    home: [11]
+    away: [13]
+sequence11:
+  coat1:
+    home: [12]
+    away: [1]
+  coat2:
+    home: [14]
+    away: [3]
+sequence12:
+  coat1:
+    home: [2]
+    away: [8]
+  coat2:
+    home: [4]
+    away: [6]
+sequence13:
+  coat1:
+    home: [5]
+    away: [12]
+  coat2:
+    home: [7]
+    away: [9]
+sequence14:
+  coat1:
+    home: [10]
+    away: [14]
+  coat2:
+    home: [11]
+    away: [1]
+sequence15:
+  coat1:
+    home: [3]
+    away: [13]
+  coat2:
+    home: [2]
+    away: [10]
+sequence16:
+  coat1:
+    home: [4]
+    away: [12]
+  coat2:
+    home: [5]
+    away: [14]
+sequence17:
+  coat1:
+    home: [6]
+    away: [11]
+  coat2:
+    home: [7]
+    away: [13]
+sequence18:
+  coat1:
+    home: [8]
+    away: [1]
+  coat2:
+    home: [9]
+    away: [3]
+sequence19:
+  coat1:
+    home: [2]
+    away: [4]
+  coat2:
+    home: [5]
+    away: [7]
+sequence20:
+  coat1:
+    home: [6]
+    away: [8]
+  coat2:
+    home: [9]
+    away: [11]
+sequence21:
+  coat1:
+    home: [10]
+    away: [12]
+  coat2:
+    home: [13]
+    away: [14]
+sequence22:
+  coat1:
+    home: [1]
+    away: [5]
+  coat2:
+    home: [2]
+    away: [6]
+sequence23:
+  coat1:
+    home: [3]
+    away: [9]
+  coat2:
+    home: [4]
+    away: [10]
+sequence24:
+  coat1:
+    home: [7]
+    away: [11]
+  coat2:
+    home: [8]
+    away: [12]
+sequence25:
+  coat1:
+    home: [13]
+    away: [2]
+  coat2:
+    home: [14]
+    away: [4]
+sequence26:
+  coat1:
+    home: [1]
+    away: [10]
+  coat2:
+    home: [3]
+    away: [12]
+sequence27:
+  coat1:
+    home: [5]
+    away: [9]
+  coat2:
+    home: [6]
+    away: [14]
+sequence28:
+  coat1:
+    home: [7]
+    away: [13]
+  coat2:
+    home: [8]
+    away: [11]
+sequence29:
+  coat1:
+    home: [2]
+    away: [12]
+  coat2:
+    home: [4]
+    away: [13]
+sequence30:
+  coat1:
+    home: [6]
+    away: [10]
+  coat2:
+    home: [8]
+    away: [14]

--- a/config/random_number_table/singles/coat2_player15.yml
+++ b/config/random_number_table/singles/coat2_player15.yml
@@ -1,0 +1,211 @@
+# コート2面、プレイヤー15人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+  coat2:
+    home: [3]
+    away: [4]
+sequence2:
+  coat1:
+    home: [5]
+    away: [6]
+  coat2:
+    home: [7]
+    away: [8]
+sequence3:
+  coat1:
+    home: [9]
+    away: [10]
+  coat2:
+    home: [11]
+    away: [12]
+sequence4:
+  coat1:
+    home: [13]
+    away: [14]
+  coat2:
+    home: [15]
+    away: [1]
+sequence5:
+  coat1:
+    home: [2]
+    away: [3]
+  coat2:
+    home: [4]
+    away: [5]
+sequence6:
+  coat1:
+    home: [6]
+    away: [7]
+  coat2:
+    home: [8]
+    away: [9]
+sequence7:
+  coat1:
+    home: [10]
+    away: [11]
+  coat2:
+    home: [12]
+    away: [13]
+sequence8:
+  coat1:
+    home: [14]
+    away: [15]
+  coat2:
+    home: [1]
+    away: [3]
+sequence9:
+  coat1:
+    home: [2]
+    away: [4]
+  coat2:
+    home: [5]
+    away: [7]
+sequence10:
+  coat1:
+    home: [6]
+    away: [8]
+  coat2:
+    home: [9]
+    away: [11]
+sequence11:
+  coat1:
+    home: [10]
+    away: [12]
+  coat2:
+    home: [13]
+    away: [15]
+sequence12:
+  coat1:
+    home: [14]
+    away: [1]
+  coat2:
+    home: [2]
+    away: [5]
+sequence13:
+  coat1:
+    home: [3]
+    away: [6]
+  coat2:
+    home: [4]
+    away: [8]
+sequence14:
+  coat1:
+    home: [7]
+    away: [10]
+  coat2:
+    home: [9]
+    away: [12]
+sequence15:
+  coat1:
+    home: [11]
+    away: [14]
+  coat2:
+    home: [13]
+    away: [2]
+sequence16:
+  coat1:
+    home: [15]
+    away: [3]
+  coat2:
+    home: [1]
+    away: [4]
+sequence17:
+  coat1:
+    home: [5]
+    away: [8]
+  coat2:
+    home: [6]
+    away: [9]
+sequence18:
+  coat1:
+    home: [7]
+    away: [11]
+  coat2:
+    home: [10]
+    away: [13]
+sequence19:
+  coat1:
+    home: [12]
+    away: [1]
+  coat2:
+    home: [14]
+    away: [2]
+sequence20:
+  coat1:
+    home: [3]
+    away: [5]
+  coat2:
+    home: [4]
+    away: [6]
+sequence21:
+  coat1:
+    home: [8]
+    away: [10]
+  coat2:
+    home: [11]
+    away: [13]
+sequence22:
+  coat1:
+    home: [15]
+    away: [14]
+  coat2:
+    home: [1]
+    away: [5]
+sequence23:
+  coat1:
+    home: [2]
+    away: [6]
+  coat2:
+    home: [3]
+    away: [7]
+sequence24:
+  coat1:
+    home: [4]
+    away: [9]
+  coat2:
+    home: [8]
+    away: [12]
+sequence25:
+  coat1:
+    home: [10]
+    away: [15]
+  coat2:
+    home: [11]
+    away: [1]
+sequence26:
+  coat1:
+    home: [13]
+    away: [3]
+  coat2:
+    home: [14]
+    away: [4]
+sequence27:
+  coat1:
+    home: [2]
+    away: [7]
+  coat2:
+    home: [5]
+    away: [9]
+sequence28:
+  coat1:
+    home: [6]
+    away: [10]
+  coat2:
+    home: [8]
+    away: [13]
+sequence29:
+  coat1:
+    home: [12]
+    away: [15]
+  coat2:
+    home: [11]
+    away: [2]
+sequence30:
+  coat1:
+    home: [1]
+    away: [6]
+  coat2:
+    home: [3]
+    away: [8]

--- a/config/random_number_table/singles/coat2_player16.yml
+++ b/config/random_number_table/singles/coat2_player16.yml
@@ -1,0 +1,211 @@
+# コート2面、プレイヤー16人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+  coat2:
+    home: [3]
+    away: [4]
+sequence2:
+  coat1:
+    home: [5]
+    away: [6]
+  coat2:
+    home: [7]
+    away: [8]
+sequence3:
+  coat1:
+    home: [9]
+    away: [10]
+  coat2:
+    home: [11]
+    away: [12]
+sequence4:
+  coat1:
+    home: [13]
+    away: [14]
+  coat2:
+    home: [15]
+    away: [16]
+sequence5:
+  coat1:
+    home: [1]
+    away: [3]
+  coat2:
+    home: [2]
+    away: [4]
+sequence6:
+  coat1:
+    home: [5]
+    away: [7]
+  coat2:
+    home: [6]
+    away: [8]
+sequence7:
+  coat1:
+    home: [9]
+    away: [11]
+  coat2:
+    home: [10]
+    away: [12]
+sequence8:
+  coat1:
+    home: [13]
+    away: [15]
+  coat2:
+    home: [14]
+    away: [16]
+sequence9:
+  coat1:
+    home: [1]
+    away: [5]
+  coat2:
+    home: [2]
+    away: [6]
+sequence10:
+  coat1:
+    home: [3]
+    away: [7]
+  coat2:
+    home: [4]
+    away: [8]
+sequence11:
+  coat1:
+    home: [9]
+    away: [13]
+  coat2:
+    home: [10]
+    away: [14]
+sequence12:
+  coat1:
+    home: [11]
+    away: [15]
+  coat2:
+    home: [12]
+    away: [16]
+sequence13:
+  coat1:
+    home: [1]
+    away: [9]
+  coat2:
+    home: [2]
+    away: [10]
+sequence14:
+  coat1:
+    home: [3]
+    away: [11]
+  coat2:
+    home: [4]
+    away: [12]
+sequence15:
+  coat1:
+    home: [5]
+    away: [13]
+  coat2:
+    home: [6]
+    away: [14]
+sequence16:
+  coat1:
+    home: [7]
+    away: [15]
+  coat2:
+    home: [8]
+    away: [16]
+sequence17:
+  coat1:
+    home: [1]
+    away: [13]
+  coat2:
+    home: [2]
+    away: [14]
+sequence18:
+  coat1:
+    home: [3]
+    away: [15]
+  coat2:
+    home: [4]
+    away: [16]
+sequence19:
+  coat1:
+    home: [5]
+    away: [9]
+  coat2:
+    home: [6]
+    away: [10]
+sequence20:
+  coat1:
+    home: [7]
+    away: [11]
+  coat2:
+    home: [8]
+    away: [12]
+sequence21:
+  coat1:
+    home: [1]
+    away: [4]
+  coat2:
+    home: [2]
+    away: [3]
+sequence22:
+  coat1:
+    home: [5]
+    away: [8]
+  coat2:
+    home: [6]
+    away: [7]
+sequence23:
+  coat1:
+    home: [9]
+    away: [12]
+  coat2:
+    home: [10]
+    away: [11]
+sequence24:
+  coat1:
+    home: [13]
+    away: [16]
+  coat2:
+    home: [14]
+    away: [15]
+sequence25:
+  coat1:
+    home: [1]
+    away: [6]
+  coat2:
+    home: [2]
+    away: [5]
+sequence26:
+  coat1:
+    home: [3]
+    away: [8]
+  coat2:
+    home: [4]
+    away: [7]
+sequence27:
+  coat1:
+    home: [9]
+    away: [14]
+  coat2:
+    home: [10]
+    away: [13]
+sequence28:
+  coat1:
+    home: [11]
+    away: [16]
+  coat2:
+    home: [12]
+    away: [15]
+sequence29:
+  coat1:
+    home: [1]
+    away: [7]
+  coat2:
+    home: [2]
+    away: [8]
+sequence30:
+  coat1:
+    home: [3]
+    away: [5]
+  coat2:
+    home: [4]
+    away: [6]

--- a/config/random_number_table/singles/coat2_player4.yml
+++ b/config/random_number_table/singles/coat2_player4.yml
@@ -1,0 +1,22 @@
+# コート2面、プレイヤー4人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+  coat2:
+    home: [3]
+    away: [4]
+sequence2:
+  coat1:
+    home: [1]
+    away: [3]
+  coat2:
+    home: [2]
+    away: [4]
+sequence3:
+  coat1:
+    home: [1]
+    away: [4]
+  coat2:
+    home: [2]
+    away: [3]

--- a/config/random_number_table/singles/coat2_player5.yml
+++ b/config/random_number_table/singles/coat2_player5.yml
@@ -1,0 +1,36 @@
+# コート2面、プレイヤー5人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+  coat2:
+    home: [3]
+    away: [4]
+sequence2:
+  coat1:
+    home: [5]
+    away: [1]
+  coat2:
+    home: [2]
+    away: [3]
+sequence3:
+  coat1:
+    home: [4]
+    away: [5]
+  coat2:
+    home: [1]
+    away: [3]
+sequence4:
+  coat1:
+    home: [2]
+    away: [4]
+  coat2:
+    home: [5]
+    away: [3]
+sequence5:
+  coat1:
+    home: [1]
+    away: [4]
+  coat2:
+    home: [2]
+    away: [5]

--- a/config/random_number_table/singles/coat2_player6.yml
+++ b/config/random_number_table/singles/coat2_player6.yml
@@ -1,0 +1,57 @@
+# コート2面、プレイヤー6人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+  coat2:
+    home: [3]
+    away: [4]
+sequence2:
+  coat1:
+    home: [5]
+    away: [6]
+  coat2:
+    home: [1]
+    away: [3]
+sequence3:
+  coat1:
+    home: [2]
+    away: [4]
+  coat2:
+    home: [5]
+    away: [1]
+sequence4:
+  coat1:
+    home: [6]
+    away: [3]
+  coat2:
+    home: [2]
+    away: [5]
+sequence5:
+  coat1:
+    home: [4]
+    away: [6]
+  coat2:
+    home: [2]
+    away: [3]
+sequence6:
+  coat1:
+    home: [1]
+    away: [4]
+  coat2:
+    home: [5]
+    away: [3]
+sequence7:
+  coat1:
+    home: [6]
+    away: [2]
+  coat2:
+    home: [4]
+    away: [5]
+sequence8:
+  coat1:
+    home: [1]
+    away: [6]
+  coat2:
+    home: [3]
+    away: [2]

--- a/config/random_number_table/singles/coat2_player7.yml
+++ b/config/random_number_table/singles/coat2_player7.yml
@@ -1,0 +1,78 @@
+# コート2面、プレイヤー7人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+  coat2:
+    home: [3]
+    away: [4]
+sequence2:
+  coat1:
+    home: [5]
+    away: [6]
+  coat2:
+    home: [7]
+    away: [1]
+sequence3:
+  coat1:
+    home: [2]
+    away: [3]
+  coat2:
+    home: [4]
+    away: [5]
+sequence4:
+  coat1:
+    home: [6]
+    away: [7]
+  coat2:
+    home: [1]
+    away: [3]
+sequence5:
+  coat1:
+    home: [2]
+    away: [4]
+  coat2:
+    home: [5]
+    away: [7]
+sequence6:
+  coat1:
+    home: [6]
+    away: [1]
+  coat2:
+    home: [3]
+    away: [5]
+sequence7:
+  coat1:
+    home: [2]
+    away: [7]
+  coat2:
+    home: [4]
+    away: [6]
+sequence8:
+  coat1:
+    home: [1]
+    away: [5]
+  coat2:
+    home: [3]
+    away: [7]
+sequence9:
+  coat1:
+    home: [2]
+    away: [6]
+  coat2:
+    home: [4]
+    away: [1]
+sequence10:
+  coat1:
+    home: [3]
+    away: [6]
+  coat2:
+    home: [5]
+    away: [2]
+sequence11:
+  coat1:
+    home: [7]
+    away: [4]
+  coat2:
+    home: [1]
+    away: [3]

--- a/config/random_number_table/singles/coat2_player8.yml
+++ b/config/random_number_table/singles/coat2_player8.yml
@@ -1,0 +1,99 @@
+# コート2面、プレイヤー8人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+  coat2:
+    home: [3]
+    away: [4]
+sequence2:
+  coat1:
+    home: [5]
+    away: [6]
+  coat2:
+    home: [7]
+    away: [8]
+sequence3:
+  coat1:
+    home: [1]
+    away: [3]
+  coat2:
+    home: [2]
+    away: [4]
+sequence4:
+  coat1:
+    home: [5]
+    away: [7]
+  coat2:
+    home: [6]
+    away: [8]
+sequence5:
+  coat1:
+    home: [1]
+    away: [4]
+  coat2:
+    home: [2]
+    away: [3]
+sequence6:
+  coat1:
+    home: [5]
+    away: [8]
+  coat2:
+    home: [6]
+    away: [7]
+sequence7:
+  coat1:
+    home: [1]
+    away: [5]
+  coat2:
+    home: [2]
+    away: [6]
+sequence8:
+  coat1:
+    home: [3]
+    away: [7]
+  coat2:
+    home: [4]
+    away: [8]
+sequence9:
+  coat1:
+    home: [1]
+    away: [6]
+  coat2:
+    home: [2]
+    away: [5]
+sequence10:
+  coat1:
+    home: [3]
+    away: [8]
+  coat2:
+    home: [4]
+    away: [7]
+sequence11:
+  coat1:
+    home: [1]
+    away: [7]
+  coat2:
+    home: [2]
+    away: [8]
+sequence12:
+  coat1:
+    home: [5]
+    away: [3]
+  coat2:
+    home: [6]
+    away: [4]
+sequence13:
+  coat1:
+    home: [1]
+    away: [8]
+  coat2:
+    home: [2]
+    away: [7]
+sequence14:
+  coat1:
+    home: [3]
+    away: [6]
+  coat2:
+    home: [4]
+    away: [5]

--- a/config/random_number_table/singles/coat2_player9.yml
+++ b/config/random_number_table/singles/coat2_player9.yml
@@ -1,0 +1,128 @@
+# コート2面、プレイヤー9人
+sequence1:
+  coat1:
+    home: [1]
+    away: [2]
+  coat2:
+    home: [3]
+    away: [4]
+sequence2:
+  coat1:
+    home: [5]
+    away: [6]
+  coat2:
+    home: [7]
+    away: [8]
+sequence3:
+  coat1:
+    home: [9]
+    away: [1]
+  coat2:
+    home: [2]
+    away: [3]
+sequence4:
+  coat1:
+    home: [4]
+    away: [5]
+  coat2:
+    home: [6]
+    away: [7]
+sequence5:
+  coat1:
+    home: [8]
+    away: [9]
+  coat2:
+    home: [1]
+    away: [3]
+sequence6:
+  coat1:
+    home: [2]
+    away: [4]
+  coat2:
+    home: [5]
+    away: [7]
+sequence7:
+  coat1:
+    home: [6]
+    away: [9]
+  coat2:
+    home: [10]
+    away: [3]
+sequence8:
+  coat1:
+    home: [1]
+    away: [4]
+  coat2:
+    home: [2]
+    away: [5]
+sequence9:
+  coat1:
+    home: [7]
+    away: [9]
+  coat2:
+    home: [6]
+    away: [3]
+sequence10:
+  coat1:
+    home: [8]
+    away: [1]
+  coat2:
+    home: [2]
+    away: [6]
+sequence11:
+  coat1:
+    home: [4]
+    away: [7]
+  coat2:
+    home: [5]
+    away: [9]
+sequence12:
+  coat1:
+    home: [8]
+    away: [3]
+  coat2:
+    home: [1]
+    away: [6]
+sequence13:
+  coat1:
+    home: [2]
+    away: [7]
+  coat2:
+    home: [4]
+    away: [9]
+sequence14:
+  coat1:
+    home: [5]
+    away: [8]
+  coat2:
+    home: [1]
+    away: [7]
+sequence15:
+  coat1:
+    home: [6]
+    away: [4]
+  coat2:
+    home: [2]
+    away: [9]
+sequence16:
+  coat1:
+    home: [3]
+    away: [5]
+  coat2:
+    home: [8]
+    away: [2]
+sequence17:
+  coat1:
+    home: [6]
+    away: [9]
+  coat2:
+    home: [1]
+    away: [5]
+sequence18:
+  coat1:
+    home: [7]
+    away: [3]
+  coat2:
+    home: [4]
+    away: [8]
+


### PR DESCRIPTION
## 前提

#14 を先に見てね

## やったこと

- 2面、16名までのシングルス・ダブルスそれぞれの乱数表のマスタデータを作りました
  - MVP開発では、対戦表の作成はアルゴリズムで組まずに、このマスタデータ通りに作成する形で実装する想定です

## レビュワーに確認して欲しいこと

- [x] YAML形式で管理することにしたんだな、ってことだけ把握しておいて欲しい