### PR TITLE
ユーザーはイベントを作成することができる

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,23 @@
+class EventsController < ApplicationController
+  def show
+    @event = Event.find(params[:id])
+  end
+
+  def new
+    @event = Event::Launch.new
+  end
+
+  def create
+    @event = Event::Launch.new(event_params)
+    event = @event.save!
+    redirect_to event_path(event)
+  rescue StandardError
+    render :new
+  end
+
+  private
+
+  def event_params
+    params.expect(event_launch: %i[name match_format number_of_coats number_of_players])
+  end
+end

--- a/app/models/event/launch.rb
+++ b/app/models/event/launch.rb
@@ -10,7 +10,7 @@ class Event::Launch
   validates! :name, presence: true, length: { maximum: 30 }
   validates! :match_format, presence: true, inclusion: { in: Event.match_formats.keys }
   validates! :number_of_coats, presence: true, numericality: { only_integer: true, in: 1..2 }
-  validates! :number_of_players, presence: true, numericality: { only_integer: true }
+  validates! :number_of_players, presence: true, numericality: { only_integer: true, in: 2..16 }
   # FIXME: rubocopに怒られている通り、lambdaを使った書き方はあまり可読性が高くないのでリファクタリングしたい
   # rubocop:disable all
   validates! :number_of_players, numericality: { less_than_or_equal_to: ->(launch) { launch.number_of_coats * 8 } }
@@ -26,6 +26,7 @@ class Event::Launch
       Player.insert_all_default_players(event:, number_of_players:)
       Match.insert_all_default_matches(event:)
       MatchPlayer.insert_all_default_match_players(event:)
+      event
     end
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -2,6 +2,8 @@ class Match < ApplicationRecord
   belongs_to :event
   has_many :match_players, dependent: :destroy
   has_many :players, through: :match_players, dependent: :destroy
+  has_many :home_players, -> { where(match_players: { side: :home }) }, through: :match_players, source: :player
+  has_many :away_players, -> { where(match_players: { side: :away }) }, through: :match_players, source: :player
 
   validates :coat_num, presence: true, numericality: { only_integer: true, greater_than: 0 }
   enum :match_format, { singles: 1, doubles: 2 }, validate: true

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,35 @@
+<h1>New event</h1>
+
+<%= form_with model: @event, url: events_path do |form| %>
+  <div>
+    <%= form.label :name %>
+    <%= form.text_field :name, value: Time.now.strftime("%Y年%m月%d日%H時%M分") %>
+  </div>
+  <div>
+    <%= form.label :match_format %>
+    <% Event.match_formats.keys.each do |key| %>
+      <div>
+        <%= form.radio_button :match_format, key, checked: key == "doubles" %>
+        <%= form.label :match_format, I18n.t("enums.event.match_format.#{key}"), value: key %>
+      </div>
+    <% end %>
+  </div>
+  <div>
+    <%= form.label :number_of_coats %>
+    <div>
+      <%= form.radio_button :number_of_coats, 1, checked: true%>
+      <%= form.label :number_of_coats, '1面', value: 1 %>
+    </div>
+    <div>
+      <%= form.radio_button :number_of_coats, 2 %>
+      <%= form.label :number_of_coats, '2面', value: 2 %>
+    </div>
+  </div>
+  <div>
+    <%= form.label :number_of_players %>
+    <%= form.number_field :number_of_players, in: 2..16, value: 4 %>
+  </div>
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,24 @@
+<h1><%= @event.name %></h1>
+
+<div id="matches">
+  <% @event.matches.order(:sequence_num, :coat_num).each do |match| %>
+    <div>
+      <h2>Sequence Number: <%= match.sequence_num %></h2>
+      <h3>Coat Number: <%= match.coat_num %></h3>
+      <h4>Home Players:</h4>
+      <ul>
+        <% match.home_players.each do |player| %>
+          <li><%= player.display_name %></li>
+        <% end %>
+      </ul>
+      <h4>Away Players</h4>
+      <ul>
+        <% match.away_players.each do |player| %>
+          <li><%= player.display_name %></li>
+        <% end %>
+      </ul>
+      <p>Home Score: <%= match.home_score %></p>
+      <p>Away Score: <%= match.away_score %></p>
+    </div>
+  <% end %>
+</div>

--- a/config/locales/models/event.ja.yml
+++ b/config/locales/models/event.ja.yml
@@ -7,3 +7,9 @@ ja:
         name: イベント名
         match_format: 試合形式
         number_of_coats: コート数
+        number_of_players: 選手数
+  enums:
+    event:
+      match_format:
+        singles: シングルス
+        doubles: ダブルス

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,7 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+  root "events#new"
+  resources :events, only: %i[show new create]
   resources :products
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe "Events", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## 関連issue

#7 

## やったこと

#7 に記載のユーザーストーリーの通り

## やっていないこと

- イベント作成画面のUI作り込み
- イベントを作成した後に遷移する詳細画面のUI作り込み
- request specを書くこと
- エラーハンドリング
  - 以下のような操作においてイベントは保存されないので適切なエラーメッセージをユーザーに見せたいが未実装
    - イベント名を空白で入力
    - 1面あたり8名を超えるような設定（コート数1, 選手数10など）
    - 試合形式がダブルスで1面あたり4名未満の設定（ダブルス、コート数1、選手数3など）
    - 試合形式がシングルスで1面あたり2名未満の設定（シングルス、コート数2、選手数2など）

## レビュワーに確認して欲しいこと

- [ ] `/`のルート画面でイベント登録ページが表示される
- [ ] イベント登録ページからイベント登録できて、詳細画面に遷移する
- [ ] 「やっていないこと > エラーハンドリング」のパターンだとイベントが保存されない