### PR TITLE
rubocopの拡張をplugins配下に記載

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,6 @@ plugins:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
-require:
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-rspec_rails


### PR DESCRIPTION
rubocopのversionが上がって、全て`plugins`に書くようになって、`require`は使わなくなったようなので修正