### PR TITLE
乱数表作成・イベント詳細画面のUI

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,4 +5,8 @@ class Event < ApplicationRecord
   validates :name, presence: true, length: { maximum: 30 }
   validates :number_of_coats, presence: true, numericality: { only_integer: true, greater_than: 0 }
   enum :match_format, { singles: 1, doubles: 2 }, validate: true
+
+  def matches_grouped_by_sequence
+    matches.order(:sequence_num, :coat_num).group_by(&:sequence_num)
+  end
 end

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,52 +1,62 @@
-<h1>乱数表の作成</h1>
+<div class="max-w-2xl mx-auto py-8 px-4">
+  <h1 class="text-3xl font-bold text-gray-800 mb-6">乱数表の作成</h1>
 
-<%= form_with model: @event, url: events_path do |form| %>
-  <div>
-    <%= form.label :name %>
-    <% @event.errors.full_messages_for(:name).each do |msg| %>
-      <span style="color:red;"><%= msg %></span><br>
-    <% end %>
-    <div>
-      <%= form.text_field :name, value: (@event.name || Time.now.strftime("%Y年%m月%d日%H時%M分")) %>
-    </div>
-  </div>
-  <div>
-    <%= form.label :match_format %>
-    <% @event.errors.full_messages_for(:match_format).each do |msg| %>
-      <span style="color:red;"><%= msg %></span><br>
-    <% end %>
-    <% Event.match_formats.keys.each do |key| %>
+  <%= form_with model: @event, url: events_path, class: "space-y-6" do |form| %>
+    <div class="space-y-2">
+      <%= form.label :name, class: "block text-sm font-medium text-gray-700" %>
+      <% @event.errors.full_messages_for(:name).each do |msg| %>
+        <span class="text-red-500 text-sm"><%= msg %></span><br>
+      <% end %>
       <div>
-        <%= form.radio_button :match_format, key, checked: key == (@event.match_format || "doubles") %>
-        <%= form.label :match_format, I18n.t("enums.event.match_format.#{key}"), value: key %>
+        <%= form.text_field :name, value: (@event.name || Time.now.strftime("%Y年%m月%d日%H時%M分")), class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
       </div>
-    <% end %>
-  </div>
-  <div>
-    <%= form.label :number_of_coats %>
-    <% @event.errors.full_messages_for(:number_of_coats).each do |msg| %>
-      <span style="color:red;"><%= msg %></span><br>
-    <% end %>
-    <div>
-      <%= form.radio_button :number_of_coats, 1, checked: (@event.number_of_coats == 1 || @event.number_of_coats.nil? ) %>
-      <%= form.label :number_of_coats, '1面', value: 1 %>
     </div>
-    <div>
-      <%= form.radio_button :number_of_coats, 2, checked: @event.number_of_coats == 2 %>
-      <%= form.label :number_of_coats, '2面', value: 2 %>
+
+    <div class="space-y-2">
+      <%= form.label :match_format, class: "block text-sm font-medium text-gray-700" %>
+      <% @event.errors.full_messages_for(:match_format).each do |msg| %>
+        <span class="text-red-500 text-sm"><%= msg %></span><br>
+      <% end %>
+      <div class="mt-2 space-y-2">
+        <% Event.match_formats.keys.each do |key| %>
+          <div class="flex items-center">
+            <%= form.radio_button :match_format, key, checked: key == (@event.match_format || "doubles"), class: "h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500" %>
+            <%= form.label :match_format, I18n.t("enums.event.match_format.#{key}"), value: key, class: "ml-2 block text-sm text-gray-700" %>
+          </div>
+        <% end %>
+      </div>
     </div>
-  </div>
-  <div>
-    <%= form.label :number_of_players %>
-    <% @event.errors.full_messages_for(:number_of_players).each do |msg| %>
-      <span style="color:red;"><%= msg %></span><br>
-    <% end %>
-    <%= form.number_field :number_of_players, in: 2..16, value: @event.number_of_players || 4 %>
-  </div>
-  <div>
-    <%= form.submit %>
-    <% if @event.errors.size > 0 %>
-      <div style="color:red;">イベントの登録に失敗しました。</div>
-    <% end %>
-  </div>
-<% end %>
+
+    <div class="space-y-2">
+      <%= form.label :number_of_coats, class: "block text-sm font-medium text-gray-700" %>
+      <% @event.errors.full_messages_for(:number_of_coats).each do |msg| %>
+        <span class="text-red-500 text-sm"><%= msg %></span><br>
+      <% end %>
+      <div class="mt-2 space-y-2">
+        <div class="flex items-center">
+          <%= form.radio_button :number_of_coats, 1, checked: (@event.number_of_coats == 1 || @event.number_of_coats.nil? ), class: "h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500" %>
+          <%= form.label :number_of_coats, '1面', value: 1, class: "ml-2 block text-sm text-gray-700" %>
+        </div>
+        <div class="flex items-center">
+          <%= form.radio_button :number_of_coats, 2, checked: @event.number_of_coats == 2, class: "h-4 w-4 text-indigo-600 border-gray-300 focus:ring-indigo-500" %>
+          <%= form.label :number_of_coats, '2面', value: 2, class: "ml-2 block text-sm text-gray-700" %>
+        </div>
+      </div>
+    </div>
+
+    <div class="space-y-2">
+      <%= form.label :number_of_players, class: "block text-sm font-medium text-gray-700" %>
+      <% @event.errors.full_messages_for(:number_of_players).each do |msg| %>
+        <span class="text-red-500 text-sm"><%= msg %></span><br>
+      <% end %>
+      <%= form.number_field :number_of_players, in: 2..16, value: @event.number_of_players || 4, class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
+    </div>
+
+    <div class="pt-4">
+      <%= form.submit class: "inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+      <% if @event.errors.size > 0 %>
+        <div class="mt-2 text-red-500 text-sm">イベントの登録に失敗しました。</div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,24 +1,57 @@
-<h1><%= @event.name %></h1>
+<div class="max-w-6xl mx-auto py-8 px-4">
+  <div class="bg-gradient-to-r from-indigo-600 to-blue-500 rounded-lg shadow-lg mb-8 p-6">
+    <h1 class="text-3xl font-bold text-white"><%= @event.name %></h1>
+    <p class="text-indigo-100 mt-2">コート数: <%= @event.number_of_coats %>面 | 試合形式: <%= t("enums.event.match_format.#{@event.match_format}") %></p>
+  </div>
 
-<div id="matches">
-  <% @event.matches.order(:sequence_num, :coat_num).each do |match| %>
-    <div>
-      <h2>Sequence Number: <%= match.sequence_num %></h2>
-      <h3>Coat Number: <%= match.coat_num %></h3>
-      <h4>Home Players:</h4>
-      <ul>
-        <% match.home_players.each do |player| %>
-          <li><%= player.display_name %></li>
-        <% end %>
-      </ul>
-      <h4>Away Players</h4>
-      <ul>
-        <% match.away_players.each do |player| %>
-          <li><%= player.display_name %></li>
-        <% end %>
-      </ul>
-      <p>Home Score: <%= match.home_score %></p>
-      <p>Away Score: <%= match.away_score %></p>
-    </div>
-  <% end %>
+  <div id="matches" class="space-y-10">
+    <% @event.matches_grouped_by_sequence.each do |sequence_num, matches| %>
+      <div class="match-group">
+        <div class="bg-gray-100 py-2 px-4 rounded-t-lg border-b-2 border-indigo-500">
+          <h2 class="text-xl font-bold text-gray-800"><%= sequence_num %></h2>
+        </div>
+        
+        <div class="space-y-4 mt-4">
+          <% matches.each do |match| %>
+            <div class="match-item bg-white rounded-lg shadow p-4">
+              <div class="text-center mb-2 bg-indigo-100 py-1 px-2 rounded-md inline-block text-indigo-800 font-medium">
+                <%= match.coat_num == 1 ? "Aコート" : "Bコート" %>
+              </div>
+              
+              <div class="flex items-center justify-between">
+                <!-- 左側（Home） -->
+                <div class="w-2/5">
+                  <ul class="space-y-1 text-center">
+                    <% match.home_players.each do |player| %>
+                      <li class="bg-blue-50 py-2 px-3 rounded-md"><%= player.display_name %></li>
+                    <% end %>
+                  </ul>
+                  <div class="mt-2 text-center">
+                    <span class="text-xl font-bold bg-blue-100 py-1 px-3 rounded-full inline-block min-w-10"><%= match.home_score %></span>
+                  </div>
+                </div>
+                
+                <!-- 中央 -->
+                <div class="text-center">
+                  <div class="text-xl font-bold text-gray-500">VS</div>
+                </div>
+                
+                <!-- 右側（Away） -->
+                <div class="w-2/5">
+                  <ul class="space-y-1 text-center">
+                    <% match.away_players.each do |player| %>
+                      <li class="bg-red-50 py-2 px-3 rounded-md"><%= player.display_name %></li>
+                    <% end %>
+                  </ul>
+                  <div class="mt-2 text-center">
+                    <span class="text-xl font-bold bg-red-100 py-1 px-3 rounded-full inline-block min-w-10"><%= match.away_score %></span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -4,51 +4,38 @@ RSpec.describe Event, type: :model do
   describe "#matches_grouped_by_sequence" do
     let(:event) { create(:event) }
 
-    context "複数のシーケンス番号を持つマッチが存在する場合" do
+    context "複数の試合順を持つマッチが存在する場合" do
       before do
-        # シーケンス番号1のマッチを2つ作成
         create(:match, event: event, sequence_num: 1, coat_num: 1)
         create(:match, event: event, sequence_num: 1, coat_num: 2)
 
-        # シーケンス番号2のマッチを2つ作成
         create(:match, event: event, sequence_num: 2, coat_num: 1)
         create(:match, event: event, sequence_num: 2, coat_num: 2)
 
-        # シーケンス番号3のマッチを1つ作成
         create(:match, event: event, sequence_num: 3, coat_num: 1)
       end
 
-      it "シーケンス番号でグループ化されたマッチのハッシュを返すこと" do
+      it "試合順でグループ化されたマッチのハッシュを返すこと" do
         result = event.matches_grouped_by_sequence
 
-        # 結果がハッシュであることを確認
         expect(result).to be_a(Hash)
 
-        # 3つのシーケンス番号のグループが存在することを確認
         expect(result.keys).to contain_exactly(1, 2, 3)
-
-        # シーケンス番号1のグループに2つのマッチが含まれることを確認
         expect(result[1].size).to eq(2)
-
-        # シーケンス番号2のグループに2つのマッチが含まれることを確認
         expect(result[2].size).to eq(2)
-
-        # シーケンス番号3のグループに1つのマッチが含まれることを確認
         expect(result[3].size).to eq(1)
       end
 
       it "コート番号でソートされていること" do
         result = event.matches_grouped_by_sequence
 
-        # シーケンス番号1のグループ内でコート番号順にソートされていることを確認
         expect(result[1].map(&:coat_num)).to eq([1, 2])
 
-        # シーケンス番号2のグループ内でコート番号順にソートされていることを確認
         expect(result[2].map(&:coat_num)).to eq([1, 2])
       end
     end
 
-    context "マッチが存在しない場合" do
+    context "試合が存在しない場合" do
       it "空のハッシュを返すこと" do
         result = event.matches_grouped_by_sequence
         expect(result).to be_empty

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,5 +1,58 @@
 require "rails_helper"
 
 RSpec.describe Event, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "#matches_grouped_by_sequence" do
+    let(:event) { create(:event) }
+
+    context "複数のシーケンス番号を持つマッチが存在する場合" do
+      before do
+        # シーケンス番号1のマッチを2つ作成
+        create(:match, event: event, sequence_num: 1, coat_num: 1)
+        create(:match, event: event, sequence_num: 1, coat_num: 2)
+
+        # シーケンス番号2のマッチを2つ作成
+        create(:match, event: event, sequence_num: 2, coat_num: 1)
+        create(:match, event: event, sequence_num: 2, coat_num: 2)
+
+        # シーケンス番号3のマッチを1つ作成
+        create(:match, event: event, sequence_num: 3, coat_num: 1)
+      end
+
+      it "シーケンス番号でグループ化されたマッチのハッシュを返すこと" do
+        result = event.matches_grouped_by_sequence
+
+        # 結果がハッシュであることを確認
+        expect(result).to be_a(Hash)
+
+        # 3つのシーケンス番号のグループが存在することを確認
+        expect(result.keys).to contain_exactly(1, 2, 3)
+
+        # シーケンス番号1のグループに2つのマッチが含まれることを確認
+        expect(result[1].size).to eq(2)
+
+        # シーケンス番号2のグループに2つのマッチが含まれることを確認
+        expect(result[2].size).to eq(2)
+
+        # シーケンス番号3のグループに1つのマッチが含まれることを確認
+        expect(result[3].size).to eq(1)
+      end
+
+      it "コート番号でソートされていること" do
+        result = event.matches_grouped_by_sequence
+
+        # シーケンス番号1のグループ内でコート番号順にソートされていることを確認
+        expect(result[1].map(&:coat_num)).to eq([1, 2])
+
+        # シーケンス番号2のグループ内でコート番号順にソートされていることを確認
+        expect(result[2].map(&:coat_num)).to eq([1, 2])
+      end
+    end
+
+    context "マッチが存在しない場合" do
+      it "空のハッシュを返すこと" do
+        result = event.matches_grouped_by_sequence
+        expect(result).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
## やったこと

- tailwindcssを使って乱数表作成・イベント詳細画面のUIを本実装しました
- イベントの持つ試合を試合順ごとにまとめるメソッド（Event#matches_grouped_by_sequence）を追加しました