### PR TITLE
成績（勝率等）画面の追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,7 +82,7 @@ RSpec/MultipleExpectations:
   Enabled: false
 
 RSpec/ExampleLength:
-  Max: 10
+  Max: 20
 
 RSpec/IndexedLet:
   Enabled: false

--- a/app/controllers/standings_controller.rb
+++ b/app/controllers/standings_controller.rb
@@ -1,0 +1,6 @@
+class StandingsController < ApplicationController
+  def show
+    @event = Event.find(params[:event_id])
+    @standings = @event.player_standings
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,4 +9,21 @@ class Event < ApplicationRecord
   def matches_grouped_by_sequence
     matches.order(:sequence_num, :coat_num).group_by(&:sequence_num)
   end
+
+  def player_standings
+    player_stats = players.map do |player|
+      {
+        id: player.id,
+        name: player.display_name,
+        wins: player.wins_count,
+        losses: player.losses_count,
+        win_rate: player.win_rate,
+        games_won: player.games_won,
+        games_lost: player.games_lost,
+        game_win_rate: player.game_win_rate
+      }
+    end
+
+    player_stats.sort_by { |stats| [-stats[:win_rate], -stats[:game_win_rate]] }
+  end
 end

--- a/app/models/player.rb
+++ b/app/models/player.rb
@@ -5,6 +5,56 @@ class Player < ApplicationRecord
 
   validates :display_name, presence: true, length: { maximum: 10 }
 
+  def wins_count
+    match_players.joins(:match).where(
+      'matches.home_score > matches.away_score AND match_players.side = ? OR
+       matches.away_score > matches.home_score AND match_players.side = ?',
+      MatchPlayer.sides[:home], MatchPlayer.sides[:away]
+    ).count
+  end
+
+  def losses_count
+    match_players.joins(:match).where(
+      'matches.home_score < matches.away_score AND match_players.side = ? OR
+       matches.away_score < matches.home_score AND match_players.side = ?',
+      MatchPlayer.sides[:home], MatchPlayer.sides[:away]
+    ).count
+  end
+
+  def win_rate
+    total = wins_count + losses_count
+    return 0 if total.zero?
+
+    (wins_count.to_f / total).round(3)
+  end
+
+  def games_won
+    home_games = match_players.joins(:match)
+                              .where(side: MatchPlayer.sides[:home])
+                              .sum("matches.home_score")
+    away_games = match_players.joins(:match)
+                              .where(side: MatchPlayer.sides[:away])
+                              .sum("matches.away_score")
+    home_games + away_games
+  end
+
+  def games_lost
+    home_games = match_players.joins(:match)
+                              .where(side: MatchPlayer.sides[:home])
+                              .sum("matches.away_score")
+    away_games = match_players.joins(:match)
+                              .where(side: MatchPlayer.sides[:away])
+                              .sum("matches.home_score")
+    home_games + away_games
+  end
+
+  def game_win_rate
+    total = games_won + games_lost
+    return 0 if total.zero?
+
+    (games_won.to_f / total).round(3)
+  end
+
   class << self
     def insert_all_default_players(event:, number_of_players:)
       players = []

--- a/app/views/standings/show.html.erb
+++ b/app/views/standings/show.html.erb
@@ -1,0 +1,24 @@
+<div class="max-w-6xl mx-auto py-8 px-4">
+  <div class="bg-gradient-to-r from-indigo-600 to-blue-500 rounded-lg shadow-lg mb-8 p-6">
+    <h1 class="text-3xl font-bold text-white"><%= @event.name %></h1>
+    <p class="text-indigo-100 mt-2">個人成績</p>
+  </div>
+  <div class="space-y-10">
+    <% @standings.each_with_index  do |standing, index| %>
+      <div class="bg-white shadow-md rounded-lg p-4 mb-4">
+        <h2 class="text-xl font-bold text-gray-800 mb-2">第<%= index + 1%>位：<%= standing[:name] %></h2>
+        <div class="border border-gray-200 rounded-lg p-4 mb-4">
+          <h3 class="text-l font-bold text-gray-800 mb-2">勝率: <%= standing[:win_rate] %></h3>
+          <p class="text-gray-600">勝利数：<%= standing[:wins] %></p>
+          <p class="text-gray-600">敗北数：<%= standing[:losses] %></p>
+        </div>
+        <div class="border border-gray-200 rounded-lg p-4">
+          <h3 class="text-l font-bold text-gray-800 mb-2">ゲーム取得率: <%= standing[:game_win_rate] %></h3>
+          <p class="text-gray-600">得ゲーム数：<%= standing[:games_won] %></p>
+          <p class="text-gray-600">失ゲーム数： <%= standing[:games_lost] %></p>
+        </div>
+      </div>
+    <% end %>
+  </div>
+  <button><%= link_to "試合結果画面に戻る", event_path(@event), class: "bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700" %></button>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,9 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
   root "events#new"
-  resources :events, only: %i[show new create]
+  resources :events, only: %i[show new create] do
+    resource :standings, only: %i[show]
+  end
   resources :matches, only: %i[update]
   resources :players, only: [] do
     collection do

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Event, type: :model do
+  describe "#player_standings" do
+    it "TODO: シングルス・ダブルスそれぞれで1パターンずつテストを追加する"
+  end
+
   describe "#matches_grouped_by_sequence" do
     let(:event) { create(:event) }
 

--- a/spec/models/player_spec.rb
+++ b/spec/models/player_spec.rb
@@ -1,6 +1,74 @@
 require "rails_helper"
 
 RSpec.describe Player, type: :model do
+  describe "勝率計算" do
+    it "勝利数 / 勝利数+敗北数 で計算されること" do
+      event = create(:event)
+      player = create(:player, event:)
+      first_match = create(:match, home_score: 4, away_score: 1, event:)
+      second_match = create(:match, home_score: 2, away_score: 4, event:)
+      third_match = create(:match, home_score: 3, away_score: 5, event:)
+      forth_match = create(:match, home_score: 5, away_score: 4, event:)
+      fifth_match = create(:match, home_score: 0, away_score: 0, event:)
+      create(:match_player, player:, match: first_match, side: :home)
+      create(:match_player, player:, match: second_match, side: :away)
+      create(:match_player, player:, match: third_match, side: :home)
+      create(:match_player, player:, match: forth_match, side: :home)
+      create(:match_player, player:, match: fifth_match, side: :home)
+
+      expect(player.wins_count).to eq(3)
+      expect(player.losses_count).to eq(1)
+      expect(player.win_rate).to eq(0.75)
+    end
+
+    it "勝利数+敗北数が0のときは0を返すこと" do
+      event = create(:event)
+      player = create(:player, event:)
+      first_match = create(:match, home_score: 0, away_score: 0, event:)
+      second_match = create(:match, home_score: 0, away_score: 0, event:)
+      create(:match_player, player:, match: first_match, side: :home)
+      create(:match_player, player:, match: second_match, side: :away)
+
+      expect(player.wins_count).to eq(0)
+      expect(player.losses_count).to eq(0)
+      expect(player.win_rate).to eq(0)
+    end
+  end
+
+  describe "取得ゲーム率計算" do
+    it "得ゲーム数 / 得ゲーム数+失ゲーム数 で計算されること" do
+      event = create(:event)
+      player = create(:player, event:)
+      first_match = create(:match, home_score: 4, away_score: 1, event:)
+      second_match = create(:match, home_score: 2, away_score: 4, event:)
+      third_match = create(:match, home_score: 3, away_score: 5, event:)
+      forth_match = create(:match, home_score: 5, away_score: 4, event:)
+      fifth_match = create(:match, home_score: 0, away_score: 0, event:)
+      create(:match_player, player:, match: first_match, side: :home)
+      create(:match_player, player:, match: second_match, side: :away)
+      create(:match_player, player:, match: third_match, side: :home)
+      create(:match_player, player:, match: forth_match, side: :home)
+      create(:match_player, player:, match: fifth_match, side: :home)
+
+      expect(player.games_won).to eq(16)
+      expect(player.games_lost).to eq(12)
+      expect(player.game_win_rate).to eq(0.571)
+    end
+
+    it "得ゲーム数+失ゲーム数が0のときは0を返すこと" do
+      event = create(:event)
+      player = create(:player, event:)
+      first_match = create(:match, home_score: 0, away_score: 0, event:)
+      second_match = create(:match, home_score: 0, away_score: 0, event:)
+      create(:match_player, player:, match: first_match, side: :home)
+      create(:match_player, player:, match: second_match, side: :away)
+
+      expect(player.games_won).to eq(0)
+      expect(player.games_lost).to eq(0)
+      expect(player.game_win_rate).to eq(0)
+    end
+  end
+
   describe ".insert_all_default_players" do
     let(:event) { create(:event) }
     let(:number_of_players) { 5 }

--- a/spec/requests/standings_spec.rb
+++ b/spec/requests/standings_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe "Standings", type: :request do
+  describe "standings#show" do
+    let(:event) { create(:event) }
+
+    it "乱数表の詳細画面が表示されること" do
+      get event_standings_path(event)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(event.name)
+    end
+  end
+end


### PR DESCRIPTION
## やったこと

- 成績画面を追加

## やっていないこと

- イベント詳細画面から成績画面への遷移するリンクの追加
  - `app/views/events/show.html.erb`が並行開発でコンフリクトしそうなので別のタイミングでやります
- あるイベントに紐付く選手を成績順に並べるメソッド（Event#player_standings）のRSpec
- 勝率もゲーム取得率も全く同じだったら同じ順位とする処理
  - 本来であれば、勝率・ゲーム数も同じだった場合は全く同じ順位にする必要があるが 、そこまでは厳密にはしていない
  - DBの挙動に任せちゃっているので、勝率・ゲーム数も同じであればidが小さい選手が上の順位として扱われるようになるはず

## レビュワーに確認して欲しいこと

- イベントを作成し、試合結果を入力していなければ、成績画面（`/events/:event_id/standings`）では全員の勝率・ゲーム取得率が0になっていること
- イベントを作成し、いくつか試合結果を入力した後に、成績画面（`/events/:event_id/standings`）に入力に応じた順位が反映されていること