### PR TITLE
選手名編集ダイアログのボタン順序変更

### DIFF
--- a/app/views/players/_name_edit_dialog.html.erb
+++ b/app/views/players/_name_edit_dialog.html.erb
@@ -12,8 +12,8 @@
         <% end %>
       </div>
       <div class="flex justify-center space-x-4 mt-6 sticky bottom-0 bg-white pt-2">
-        <%= f.submit "一括更新", class: "bg-indigo-600 text-white py-2 px-6 rounded-md hover:bg-indigo-700", data: { player_name_target: "submitButton" } %>
         <button type="button" class="bg-gray-200 text-gray-700 py-2 px-6 rounded-md hover:bg-gray-300" data-action="click->player-name#closeDialog">キャンセル</button>
+        <%= f.submit "一括更新", class: "bg-indigo-600 text-white py-2 px-6 rounded-md hover:bg-indigo-700", data: { player_name_target: "submitButton" } %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
## やったこと

キャンセルボタンが左側に、一括更新ボタンが右側に配置されるようになりました（一般的なUIはこっちらしい）

<img width="474" alt="スクリーンショット 2025-05-04 8 28 19" src="https://github.com/user-attachments/assets/331f5a33-0981-4fe4-8928-ff78e91d1369" />
