### PR TITLE
イベント名はHeaderに表示する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+  def display_event_name(event)
+    if defined?(event) && event.present? && event.respond_to?(:id) && event.id.present?
+      event.name
+    else
+      "テニスの乱数表"
+    end
+  end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,7 +2,7 @@
   <div class="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
     <div class="flex items-center">
       <h1 class="text-xl font-bold text-white"><%= link_to "Ransurec", root_path %></h1>
-      <p class="ml-3 text-sm text-indigo-200">テニスの乱数表</p>
+      <p class="ml-3 text-sm text-indigo-200"><%= display_event_name(@event) %></p>
     </div>
   </div>
 </header> 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe ApplicationHelper, type: :helper do
+  # rubocop:disable RSpec/VerifiedDoubles, RSpec/ReceiveMessages
+  describe "#display_event_name" do
+    context "イベントが有効な場合" do
+      it "保存済みイベントの名前を返すこと" do
+        event = double("Event", id: 1, name: "テスト大会")
+        allow(event).to receive(:present?).and_return(true)
+        allow(event).to receive(:respond_to?).with(:id).and_return(true)
+        expect(helper.display_event_name(event)).to eq("テスト大会")
+      end
+    end
+
+    context "イベントが無効な場合" do
+      it "nilの場合はデフォルトテキストを返すこと" do
+        expect(helper.display_event_name(nil)).to eq("テニスの乱数表")
+      end
+
+      it "空のイベントの場合はデフォルトテキストを返すこと" do
+        event = double("Event")
+        allow(event).to receive(:present?).and_return(true)
+        allow(event).to receive(:respond_to?).with(:id).and_return(true)
+        allow(event).to receive(:id).and_return(nil)
+        expect(helper.display_event_name(event)).to eq("テニスの乱数表")
+      end
+
+      it "idメソッドがないイベントの場合はデフォルトテキストを返すこと" do
+        event = double("Event::Launch")
+        allow(event).to receive(:present?).and_return(true)
+        allow(event).to receive(:respond_to?).with(any_args).and_return(true)
+        allow(event).to receive(:respond_to?).with(:id).and_return(false)
+        expect(helper.display_event_name(event)).to eq("テニスの乱数表")
+      end
+    end
+  end
+  # rubocop:enable RSpec/VerifiedDoubles, RSpec/ReceiveMessages
+end


### PR DESCRIPTION
## やったこと

Header上に、イベントに関連するページではイベント名を表示し、それ以外の場合は「テニスの乱数表」と表示されるようにしました