### PR TITLE
イベント名入力を任意化

### DIFF
--- a/app/models/event/launch.rb
+++ b/app/models/event/launch.rb
@@ -7,7 +7,7 @@ class Event::Launch
   attribute :number_of_coats, :integer
   attribute :number_of_players, :integer
 
-  validates :name, presence: true, length: { maximum: 30 }
+  validates :name, length: { maximum: 30 }
   validates :match_format, presence: true, inclusion: { in: Event.match_formats.keys }
   validates :number_of_coats, presence: true, numericality: { only_integer: true, in: 1..2 }
   validates :number_of_players, presence: true, numericality: { only_integer: true, in: 2..16 }
@@ -22,6 +22,8 @@ class Event::Launch
     return false if invalid?
 
     ApplicationRecord.transaction do
+      self.name = Time.zone.now.strftime("%Y年%m月%d日の乱数表") if name.blank?
+
       event = Event.create!(name:, match_format:, number_of_coats:)
       Player.insert_all_default_players(event:, number_of_players:)
       Match.insert_all_default_matches(event:)

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -3,17 +3,10 @@
 <div class="max-w-2xl mx-auto py-8 px-4">
   <%= form_with model: @event, url: events_path, class: "space-y-6" do |form| %>
     <div class="space-y-2">
-      <%= form.label :name, class: "block text-sm font-medium text-gray-700" %>
-      <% @event.errors.full_messages_for(:name).each do |msg| %>
-        <span class="text-red-500 text-sm"><%= msg %></span><br>
-      <% end %>
-      <div>
-        <%= form.text_field :name, value: (@event.name || Time.now.strftime("%Y年%m月%d日%H時%M分")), class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
+      <div class="flex items-center">
+        <%= form.label :match_format, class: "block text-sm font-medium text-gray-700" %>
+        <span class="inline-block ml-1 px-2 py-0.5 text-xs font-semibold rounded-full bg-red-100 text-red-800">必須</span>
       </div>
-    </div>
-
-    <div class="space-y-2">
-      <%= form.label :match_format, class: "block text-sm font-medium text-gray-700" %>
       <% @event.errors.full_messages_for(:match_format).each do |msg| %>
         <span class="text-red-500 text-sm"><%= msg %></span><br>
       <% end %>
@@ -28,7 +21,10 @@
     </div>
 
     <div class="space-y-2">
-      <%= form.label :number_of_coats, class: "block text-sm font-medium text-gray-700" %>
+      <div class="flex items-center">
+        <%= form.label :number_of_coats, class: "block text-sm font-medium text-gray-700" %>
+        <span class="inline-block ml-1 px-2 py-0.5 text-xs font-semibold rounded-full bg-red-100 text-red-800">必須</span>
+      </div>
       <% @event.errors.full_messages_for(:number_of_coats).each do |msg| %>
         <span class="text-red-500 text-sm"><%= msg %></span><br>
       <% end %>
@@ -45,11 +41,27 @@
     </div>
 
     <div class="space-y-2">
-      <%= form.label :number_of_players, class: "block text-sm font-medium text-gray-700" %>
+      <div class="flex items-center">
+        <%= form.label :number_of_players, class: "block text-sm font-medium text-gray-700" %>
+        <span class="inline-block ml-1 px-2 py-0.5 text-xs font-semibold rounded-full bg-red-100 text-red-800">必須</span>
+      </div>
       <% @event.errors.full_messages_for(:number_of_players).each do |msg| %>
         <span class="text-red-500 text-sm"><%= msg %></span><br>
       <% end %>
       <%= form.number_field :number_of_players, in: 2..16, value: @event.number_of_players || 4, class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
+    </div>
+
+    <div class="space-y-2">
+      <div class="flex items-center">
+        <%= form.label :name, class: "block text-sm font-medium text-gray-700" %>
+        <span class="inline-block ml-1 px-2 py-0.5 text-xs font-semibold rounded-full bg-gray-100 text-gray-600">任意</span>
+      </div>
+      <% @event.errors.full_messages_for(:name).each do |msg| %>
+        <span class="text-red-500 text-sm"><%= msg %></span><br>
+      <% end %>
+      <div>
+        <%= form.text_field :name, placeholder: Time.zone.now.strftime("%Y年%m月%d日の乱数表"), class: "mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" %>
+      </div>
     </div>
 
     <div class="pt-4 text-center">

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe "events", type: :system do
         visit "/"
 
         expect do
-          click_on "乱数表を"
+          click_on "乱数表を作成"
 
-          expect(page).to have_text(/\d{4}年\d{2}月\d{2}日\d{2}時\d{2}分/)
+          expect(page).to have_text(/\d{4}年\d{2}月\d{2}日/)
         end.to change(Event, :count).by(1)
       end
     end


### PR DESCRIPTION
## やったこと

- イベント名の入力を任意にしました
- ユーザーがイベント名を空欄でSubmitしてきたときは自動で "YYYY年MM月DD日の乱数表"というイベント名で保存されるようにしました
- イベント名が任意になったので入力欄の一番したに移動しました
- 入力欄に「必須」「任意」のアイコンをつけました