### PR TITLE
スコア入力ダイアログのキャンセル時の挙動修正

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -43,11 +43,18 @@ class MatchesController < ApplicationController
     end
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: turbo_stream.replace(
-          "dialog_match_id_#{@match.id}",
-          partial: "matches/score_dialog",
-          locals: { match: @match, status: @status }
-        )
+        render turbo_stream: [
+          turbo_stream.replace(
+            "dialog_match_id_#{@match.id}",
+            partial: "matches/score_dialog",
+            locals: { match: @match, status: @status }
+          ),
+          turbo_stream.replace(
+            "match_id_#{@match.id}",
+            partial: "matches/match_detail",
+            locals: { match: @match }
+          )
+        ]
       end
     end
   end


### PR DESCRIPTION
## やったこと

### MatchesController#show_score_dialogの挙動修正

#### 内容

show_score_dialogでもmatch_detailのpartialをturbo_stream.replaceさせた

#### 意図

- (1)あるユーザーがある試合のスコア入力を完了させる
- (2)もう一人のユーザーが同じ試合のスコア入力をしようとすると、すでにスコアが入っていることに気付く
- (3)安心してxボタンを押すと、自分の画面では古いスコアのままになってしまう

という挙動がユーザーの混乱を招くため、(3)の段階で最新のスコアを画面に反映させるように修正した