### PR TITLE
試合順の表示を控え目にする

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -27,8 +27,8 @@
   <div id="matches" class="space-y-10">
     <% @event.matches_grouped_by_sequence.each do |sequence_num, matches| %>
       <div class="match-group">
-        <div class="bg-gray-100 py-2 px-4 rounded-t-lg border-b-2 border-indigo-500">
-          <h2 class="text-xl font-bold text-gray-800"><%= sequence_num %></h2>
+        <div class="bg-gray-50 py-1 px-4 rounded-t-lg border-b border-gray-300">
+          <h2 class="text-sm font-normal text-gray-600"><%= sequence_num %></h2>
         </div>
           <div class="space-y-4 mt-4">
             <% matches.each do |match| %>


### PR DESCRIPTION
## やったこと

試合順を表示する部分が、悪目立ちしすぎてクリック可能なエリアに誤認されそうだったので控え目にしました

### Before
<img width="398" alt="スクリーンショット 2025-05-05 10 31 14" src="https://github.com/user-attachments/assets/1c7b0f71-e2fe-40a9-bad4-ee18297461df" />

### After
<img width="398" alt="スクリーンショット 2025-05-05 10 31 06" src="https://github.com/user-attachments/assets/6b1fd954-9e63-4589-9f41-18836085c1cf" />
