### PR TITLE
ペア組み替え機能

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -59,6 +59,24 @@ class MatchesController < ApplicationController
     end
   end
 
+  def rotate
+    @match = Match.find(params[:id])
+    @match.rotate_match_players
+
+    respond_to do |format|
+      format.html { redirect_to event_path(@match.event), notice: I18n.t("match.notices.rotated") }
+      format.turbo_stream do
+        render turbo_stream: [
+          turbo_stream.replace(
+            "match_id_#{@match.id}",
+            partial: "matches/match_detail",
+            locals: { match: @match }
+          )
+        ]
+      end
+    end
+  end
+
   private
 
   def match_params

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -9,6 +9,24 @@ class Match < ApplicationRecord
   validates :home_score, :away_score, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   enum :match_format, { singles: 1, doubles: 2 }, validate: true
 
+  def rotate_match_players
+    return unless doubles?
+
+    sorted_match_players = match_players.order(:id)
+    return if sorted_match_players.size != 4
+
+    rotating_players = sorted_match_players[1..3]
+    player_ids = rotating_players.map(&:player_id)
+
+    rotated_player_ids = [player_ids[2], player_ids[0], player_ids[1]]
+
+    rotating_players.each_with_index do |mp, index|
+      mp.update!(player_id: rotated_player_ids[index])
+    end
+
+    match_players.reload
+  end
+
   class << self
     def insert_all_default_matches(event:)
       matches = []

--- a/app/views/matches/_match_detail.html.erb
+++ b/app/views/matches/_match_detail.html.erb
@@ -16,7 +16,12 @@
       <% end %>
     </div>
     <div class="text-center">
-      <div class="text-xl font-bold text-gray-500">VS</div>
+      <div class="text-xl font-bold text-gray-500 mb-1">VS</div>
+      <% if match.doubles? %>
+        <%= link_to rotate_match_path(match), data: { turbo_method: :post, turbo_stream: true }, class:"text-xs bg-yellow-500 text-white py-1 px-2 rounded-md inline-block cursor-pointer hover:bg-yellow-600" do %>
+          ペア交代
+        <% end %>
+      <% end %>
     </div>
     <div class="w-2/5">
       <ul class="space-y-1 text-center">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   resources :matches, only: %i[update] do 
     member do
       get :show_score_dialog
+      post :rotate
     end
   end
   resources :players, only: [] do

--- a/spec/factories/match_players.rb
+++ b/spec/factories/match_players.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :match_player do
-    side { rand(1..2) }
+    side { %i[home away].sample }
   end
 end

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -68,4 +68,65 @@ RSpec.describe Match, type: :model do
       end
     end
   end
+
+  describe "#rotate_match_players" do
+    let(:event) { create(:event, match_format:) }
+    let(:match) { create(:match, event:, match_format:) }
+    let(:players) { create_list(:player, 4, event:) }
+
+    context "シングルスの場合" do
+      let(:match_format) { "singles" }
+
+      before do
+        create(:match_player, match:, player: players[0], side: :home)
+        create(:match_player, match:, player: players[1], side: :away)
+      end
+
+      it "プレイヤーのローテーションが行われないこと" do
+        original_player_ids = match.match_players.order(:id).pluck(:player_id)
+
+        match.rotate_match_players
+
+        expect(match.match_players.order(:id).pluck(:player_id)).to eq(original_player_ids)
+      end
+    end
+
+    context "ダブルスの場合" do
+      let(:match_format) { "doubles" }
+
+      before do
+        create(:match_player, match:, player: players[0], side: :home)
+        create(:match_player, match:, player: players[1], side: :home)
+        create(:match_player, match:, player: players[2], side: :away)
+        create(:match_player, match:, player: players[3], side: :away)
+      end
+
+      it "最初のプレイヤーを固定し、残りの3人がローテーションすること" do
+        original_player_ids = match.match_players.order(:id).pluck(:player_id)
+
+        match.rotate_match_players
+        rotated_player_ids = match.match_players.order(:id).pluck(:player_id)
+
+        expect(rotated_player_ids[0]).to eq(original_player_ids[0])
+
+        expect(rotated_player_ids[1]).to eq(original_player_ids[3])
+        expect(rotated_player_ids[2]).to eq(original_player_ids[1])
+        expect(rotated_player_ids[3]).to eq(original_player_ids[2])
+
+        match.rotate_match_players
+        second_rotation_player_ids = match.match_players.order(:id).pluck(:player_id)
+
+        expect(second_rotation_player_ids[0]).to eq(original_player_ids[0])
+
+        expect(second_rotation_player_ids[1]).to eq(original_player_ids[2])
+        expect(second_rotation_player_ids[2]).to eq(original_player_ids[3])
+        expect(second_rotation_player_ids[3]).to eq(original_player_ids[1])
+
+        match.rotate_match_players
+        third_rotation_player_ids = match.match_players.order(:id).pluck(:player_id)
+
+        expect(third_rotation_player_ids).to eq(original_player_ids)
+      end
+    end
+  end
 end

--- a/spec/requests/matches_spec.rb
+++ b/spec/requests/matches_spec.rb
@@ -54,4 +54,81 @@ RSpec.describe "Matches", type: :request do
       end
     end
   end
+
+  describe "match#rotate" do
+    let(:event) { create(:event, match_format: "doubles") }
+    let(:match) { create(:match, event: event, match_format: "doubles") }
+    let(:players) { create_list(:player, 4, event: event) }
+
+    before do
+      # 4人のプレイヤーをマッチに関連付け
+      create(:match_player, match: match, player: players[0], side: :home)
+      create(:match_player, match: match, player: players[1], side: :home)
+      create(:match_player, match: match, player: players[2], side: :away)
+      create(:match_player, match: match, player: players[3], side: :away)
+    end
+
+    context "HTMLリクエストの場合" do
+      it "プレイヤーがローテーションされ、イベント詳細ページにリダイレクトされること" do
+        # プレイヤーIDを取得
+        original_player_ids = match.match_players.order(:id).pluck(:player_id)
+
+        # ローテーションリクエストを送信
+        post rotate_match_path(match)
+
+        # リダイレクトを確認
+        expect(response).to redirect_to(event_path(event))
+        expect(flash[:notice]).to eq(I18n.t("match.notices.rotated"))
+
+        # プレイヤーがローテーションされていることを確認
+        rotated_player_ids = match.reload.match_players.order(:id).pluck(:player_id)
+        expect(rotated_player_ids[0]).to eq(original_player_ids[0]) # 固定プレイヤー
+        expect(rotated_player_ids[1]).to eq(original_player_ids[3])
+        expect(rotated_player_ids[2]).to eq(original_player_ids[1])
+        expect(rotated_player_ids[3]).to eq(original_player_ids[2])
+      end
+    end
+
+    context "Turbo Streamリクエストの場合" do
+      it "プレイヤーがローテーションされ、Turbo Streamレスポンスが返ること" do
+        # プレイヤーIDを取得
+        original_player_ids = match.match_players.order(:id).pluck(:player_id)
+
+        # ローテーションリクエストを送信（Turbo Stream形式で）
+        post rotate_match_path(match), headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+        # レスポンスを確認
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+
+        # レスポンス内容にマッチIDが含まれていることを確認
+        expect(response.body).to include("match_id_#{match.id}")
+
+        # プレイヤーがローテーションされていることを確認
+        rotated_player_ids = match.reload.match_players.order(:id).pluck(:player_id)
+        expect(rotated_player_ids[0]).to eq(original_player_ids[0]) # 固定プレイヤー
+        expect(rotated_player_ids[1]).to eq(original_player_ids[3])
+        expect(rotated_player_ids[2]).to eq(original_player_ids[1])
+        expect(rotated_player_ids[3]).to eq(original_player_ids[2])
+      end
+    end
+
+    context "シングルスの試合の場合" do
+      let(:singles_match) { create(:match, event: event, match_format: "singles") }
+      let(:singles_players) { create_list(:player, 2, event: event) }
+
+      before do
+        create(:match_player, match: singles_match, player: singles_players[0], side: :home)
+        create(:match_player, match: singles_match, player: singles_players[1], side: :away)
+      end
+
+      it "プレイヤーがローテーションされないこと" do
+        original_player_ids = singles_match.match_players.order(:id).pluck(:player_id)
+
+        post rotate_match_path(singles_match)
+
+        expect(singles_match.reload.match_players.order(:id).pluck(:player_id)).to eq(original_player_ids)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## やったこと

ダブルスの同じ試合に指定された4人のペアを組み替えられるような機能を実装した

内部的には、idが一番若いMatchPlayerを固定して、残り3つのMatchPlayerのplayer_idをローテーションさせるメソッドを新設しています